### PR TITLE
Separate sandbox branch from console branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,10 @@
 name: Publish to PyPI
 
 on:
-  # Trigger on release creation
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'           # v1.0.0 → publishes do-app-sandbox from main
+      - 'console-v*'   # console-v1.0.0 → publishes do-app-console from console branch
 
   # Manual trigger from GitHub Actions UI
   workflow_dispatch:
@@ -21,6 +22,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Determine package name
+        id: package
+        run: |
+          # Extract package name from pyproject.toml
+          PACKAGE_NAME=$(grep '^name = ' pyproject.toml | sed 's/name = "\(.*\)"/\1/')
+          echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+          echo "Publishing package: $PACKAGE_NAME"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -48,6 +57,8 @@ jobs:
         run: |
           echo "## Published to PyPI! 🎉" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Package:** do-app-sandbox" >> $GITHUB_STEP_SUMMARY
+          echo "**Package:** ${{ steps.package.outputs.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Files:**" >> $GITHUB_STEP_SUMMARY
           ls -la dist/ >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > **Experimental**: This is a personal project and is not officially supported by DigitalOcean. APIs may change without notice.
 
+This is part of 3 projects to scale Agentic workflows with DigitalOcean App Platform. The concepts are generic and should work with any PaaS:
+- Safe local sandboxing using DevContainers ([do-app-devcontainer](https://github.com/bikramkgupta/do-app-devcontainer))
+- Rapid development iteration using hot reload ([do-app-hot-reload-template](https://github.com/bikramkgupta/do-app-hot-reload-template))
+- Disposable environments using sandboxes for parallel experimentation and debugging (this repo or [do-app-sandbox](https://github.com/bikramkgupta/do-app-sandbox))
+
 A Python SDK that provides sandbox-like capabilities for DigitalOcean App Platform, similar to Cloudflare Sandbox.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -2,12 +2,28 @@
 
 > **Experimental**: This is a personal project and is not officially supported by DigitalOcean. APIs may change without notice.
 
-This is part of 3 projects to scale Agentic workflows with DigitalOcean App Platform. The concepts are generic and should work with any PaaS:
-- Safe local sandboxing using DevContainers ([do-app-devcontainer](https://github.com/bikramkgupta/do-app-devcontainer))
-- Rapid development iteration using hot reload ([do-app-hot-reload-template](https://github.com/bikramkgupta/do-app-hot-reload-template))
-- Disposable environments using sandboxes for parallel experimentation and debugging (this repo or [do-app-sandbox](https://github.com/bikramkgupta/do-app-sandbox))
+A Python SDK for creating disposable sandbox environments on DigitalOcean App Platform.
 
-A Python SDK that provides sandbox-like capabilities for DigitalOcean App Platform, similar to Cloudflare Sandbox.
+**Looking to troubleshoot existing App Platform apps?** See [do-app-console](https://github.com/bikramkgupta/do-app-console) — the same toolkit focused on connecting to and debugging your production apps.
+
+## What This Package Does
+
+**DO App Sandbox** is designed for creating **new, temporary sandbox environments**:
+
+```python
+from do_app_sandbox import Sandbox
+
+# Create a fresh sandbox environment
+sandbox = Sandbox.create(image="python", name="my-experiment")
+sandbox.exec("pip install pandas && python analyze.py")
+sandbox.delete()  # Clean up when done
+```
+
+Use cases:
+- **Parallel experimentation**: Spin up multiple isolated environments
+- **CI/CD testing**: Create fresh environments for each test run
+- **Safe code execution**: Run untrusted code in disposable containers
+- **Development sandboxes**: Quick environments without local setup
 
 ## Features
 
@@ -18,11 +34,18 @@ A Python SDK that provides sandbox-like capabilities for DigitalOcean App Platfo
 - **Async support**: Both synchronous and asynchronous APIs
 - **CLI tool**: Manage sandboxes from the command line
 - **Hosted images**: Uses maintained Python and Node images; no custom image setup required
-- **Troubleshoot existing apps**: Connect to any App Platform app for troubleshooting ([guide](docs/troubleshooting_existing_apps.md))
+
+## Related Projects
+
+This is part of 3 projects to scale Agentic workflows with DigitalOcean App Platform:
+- [do-app-devcontainer](https://github.com/bikramkgupta/do-app-devcontainer) — Safe local sandboxing using DevContainers
+- [do-app-hot-reload-template](https://github.com/bikramkgupta/do-app-hot-reload-template) — Rapid development iteration using hot reload
+- [do-app-console](https://github.com/bikramkgupta/do-app-console) — Remote console for troubleshooting existing apps
 
 ## Documentation
+
 - Reference tables for SDK and CLI parameters/outputs: `docs/sandbox_reference.md`
-- Troubleshooting existing App Platform apps: `docs/troubleshooting_existing_apps.md`
+- Lifecycle management guide: `docs/sandbox_lifecycle.md`
 
 ## Installation
 

--- a/src/do_app_sandbox/branding.py
+++ b/src/do_app_sandbox/branding.py
@@ -1,0 +1,83 @@
+"""Branding constants for the package.
+
+This file contains all user-facing strings that differ between the sandbox
+and console variants of this package. To create a different branded version,
+only this file (plus pyproject.toml and README.md) needs to change.
+
+On the main branch: PRODUCT_NAME = "sandbox" (do-app-sandbox package)
+On the console branch: PRODUCT_NAME = "console" (do-app-console package)
+"""
+
+# =============================================================================
+# CORE BRANDING - Change these for different package variants
+# =============================================================================
+
+PRODUCT_NAME = "sandbox"
+PRODUCT_NAME_PLURAL = "sandboxes"
+CLI_COMMAND = "sandbox"
+
+# Package description (shown in --version and help)
+PRODUCT_DESCRIPTION = "Manage sandbox environments on DigitalOcean App Platform"
+PRODUCT_VERSION = "0.1.2"
+
+# =============================================================================
+# CLI HELP TEXT
+# =============================================================================
+
+HELP_MAIN = "Manage sandbox environments on DigitalOcean App Platform"
+HELP_SETUP = "Build and push sandbox images to your DOCR registry"
+HELP_CREATE = "Create a new sandbox"
+HELP_LIST = "List all sandboxes"
+HELP_DELETE = "Delete a sandbox"
+HELP_EXEC = "Execute a command in a sandbox"
+HELP_IMAGE = "Manage custom sandbox images"
+
+# Argument help
+HELP_ARG_NAME = "Name for the sandbox (auto-generated if not provided)"
+HELP_ARG_TARGET = "Sandbox name or ID"
+HELP_ARG_DELETE_NAME = "Sandbox name to delete"
+
+# =============================================================================
+# USER-FACING MESSAGES
+# =============================================================================
+
+# Create messages
+MSG_CREATING = "Creating sandbox..."
+MSG_CREATED = "Sandbox created successfully!"
+MSG_CREATE_ERROR = "Error creating sandbox: {error}"
+
+# List messages
+MSG_LIST_EMPTY = "No sandboxes found."
+MSG_LIST_ERROR = "Error listing sandboxes: {error}"
+
+# Delete messages
+MSG_DELETE_CONFIRM_ALL = "Are you sure you want to delete ALL sandboxes? [y/N]: "
+MSG_DELETE_NONE = "No sandboxes to delete."
+MSG_DELETED = "Deleted: {name} ({app_id})"
+MSG_DELETE_FAILED = "Failed to delete {name}: {error}"
+MSG_DELETE_COUNT = "Deleted {count} sandbox(es)."
+MSG_DELETE_SUCCESS = "Deleted sandbox: {target}"
+MSG_DELETE_ERROR = "Error deleting sandbox: {error}"
+MSG_NOT_FOUND = "Sandbox '{name}' not found."
+
+# Exec messages
+MSG_EXEC_ERROR = "Error executing command: {error}"
+
+# Status messages (for --no-wait)
+MSG_STILL_DEPLOYING = "Note: Sandbox may still be deploying. Use '{cmd} list' to check status."
+
+# =============================================================================
+# DOCSTRINGS (for module-level documentation)
+# =============================================================================
+
+CLI_MODULE_DOC = """Command-line interface for App Platform Sandbox.
+
+This module provides a CLI for managing sandbox environments on DigitalOcean App Platform.
+
+Usage:
+    {cmd} setup --registry MY_REGISTRY    # Build and push images
+    {cmd} create --image python           # Create a new sandbox
+    {cmd} list                            # List all sandboxes
+    {cmd} delete NAME                     # Delete a sandbox
+    {cmd} exec NAME "command"             # Execute a command
+""".format(cmd=CLI_COMMAND)

--- a/src/do_app_sandbox/cli.py
+++ b/src/do_app_sandbox/cli.py
@@ -1,13 +1,7 @@
 """Command-line interface for App Platform Sandbox.
 
 This module provides a CLI for managing sandbox environments on DigitalOcean App Platform.
-
-Usage:
-    sandbox setup --registry MY_REGISTRY    # Build and push images
-    sandbox create --image python           # Create a new sandbox
-    sandbox list                            # List all sandboxes
-    sandbox delete NAME                     # Delete a sandbox
-    sandbox exec NAME "command"             # Execute a command
+See branding.py for user-facing strings that differ between package variants.
 """
 
 import argparse
@@ -29,6 +23,7 @@ from .deployer import (
 )
 from .sandbox import ENV_REGION, ENV_REGISTRY, Sandbox
 from .image_registry import ImageRegistry
+from . import branding as B
 
 
 def ensure_doctl_available() -> bool:
@@ -311,7 +306,7 @@ def cmd_create(args: argparse.Namespace) -> int:
 
     registry_display = f"{registry}/{DEFAULT_IMAGE_OWNER}"
 
-    print(f"Creating sandbox...")
+    print(B.MSG_CREATING)
     print(f"  Image: {args.image}")
     print(f"  Type: {component_type}")
     print(f"  Registry: {registry_display}")
@@ -330,7 +325,7 @@ def cmd_create(args: argparse.Namespace) -> int:
             registry=registry,
             wait_ready=not args.no_wait,
         )
-        print(f"\nSandbox created successfully!")
+        print(f"\n{B.MSG_CREATED}")
         print(f"  ID: {sandbox.app_id}")
         url = sandbox.get_url()
         if url:
@@ -340,11 +335,11 @@ def cmd_create(args: argparse.Namespace) -> int:
         print(f"  Status: {sandbox.status}")
 
         if args.no_wait:
-            print("\nNote: Sandbox may still be deploying. Use 'sandbox list' to check status.")
+            print(f"\n{B.MSG_STILL_DEPLOYING.format(cmd=B.CLI_COMMAND)}")
 
         return 0
     except Exception as e:
-        print(f"Error creating sandbox: {e}")
+        print(B.MSG_CREATE_ERROR.format(error=e))
         return 1
 
 
@@ -400,7 +395,7 @@ def cmd_list(args: argparse.Namespace) -> int:
             return 0
 
         if not sandboxes:
-            print("No sandboxes found.")
+            print(B.MSG_LIST_EMPTY)
             return 0
 
         # Print table header
@@ -418,7 +413,7 @@ def cmd_list(args: argparse.Namespace) -> int:
 
         return 0
     except Exception as e:
-        print(f"Error listing sandboxes: {e}")
+        print(B.MSG_LIST_ERROR.format(error=e))
         return 1
 
 
@@ -435,7 +430,7 @@ def cmd_delete(args: argparse.Namespace) -> int:
     if args.all:
         # Delete all sandboxes
         if not args.force:
-            confirm = input("Are you sure you want to delete ALL sandboxes? [y/N]: ")
+            confirm = input(B.MSG_DELETE_CONFIRM_ALL)
             if confirm.lower() != "y":
                 print("Cancelled.")
                 return 0
@@ -473,7 +468,7 @@ def cmd_delete(args: argparse.Namespace) -> int:
             sandboxes.append(app)
 
         if not sandboxes:
-            print("No sandboxes to delete.")
+            print(B.MSG_DELETE_NONE)
             return 0
 
         deleted = 0
@@ -482,12 +477,12 @@ def cmd_delete(args: argparse.Namespace) -> int:
             name = app.get("spec", {}).get("name", "")
             try:
                 deployer.delete_app(app_id)
-                print(f"Deleted: {name} ({app_id})")
+                print(B.MSG_DELETED.format(name=name, app_id=app_id))
                 deleted += 1
             except Exception as e:
-                print(f"Failed to delete {name}: {e}")
+                print(B.MSG_DELETE_FAILED.format(name=name, error=e))
 
-        print(f"\nDeleted {deleted} sandbox(es).")
+        print(f"\n{B.MSG_DELETE_COUNT.format(count=deleted)}")
         return 0
 
     # Delete specific sandbox
@@ -513,17 +508,17 @@ def cmd_delete(args: argparse.Namespace) -> int:
         ]
 
         if not matching:
-            print(f"Sandbox '{target}' not found.")
+            print(B.MSG_NOT_FOUND.format(name=target))
             return 1
 
         app_id = matching[0].get("id", "")
 
     try:
         deployer.delete_app(app_id)
-        print(f"Deleted sandbox: {target}")
+        print(B.MSG_DELETE_SUCCESS.format(target=target))
         return 0
     except Exception as e:
-        print(f"Error deleting sandbox: {e}")
+        print(B.MSG_DELETE_ERROR.format(error=e))
         return 1
 
 
@@ -553,7 +548,7 @@ def cmd_exec(args: argparse.Namespace) -> int:
         ]
 
         if not matching:
-            print(f"Sandbox '{target}' not found.")
+            print(B.MSG_NOT_FOUND.format(name=target))
             return 1
 
         app_id = matching[0].get("id", "")
@@ -569,7 +564,7 @@ def cmd_exec(args: argparse.Namespace) -> int:
 
         return result.exit_code
     except Exception as e:
-        print(f"Error executing command: {e}")
+        print(B.MSG_EXEC_ERROR.format(error=e))
         return 1
 
 
@@ -613,7 +608,7 @@ def cmd_image_add(args: argparse.Namespace) -> int:
         image_registry.update_status(args.name, "validating", validation_pid=proc.pid)
 
         print(f"\nValidation started (PID: {proc.pid})")
-        print(f"Check status with: sandbox image status {args.name}")
+        print(f"Check status with: {B.CLI_COMMAND} image status {args.name}")
 
         return 0
     except ValueError as e:
@@ -675,7 +670,7 @@ def cmd_image_status(args: argparse.Namespace) -> int:
                     for line in f:
                         print(f"  {line}", end="")
             else:
-                print(f"\n  View logs with: sandbox image status {args.name} --logs")
+                print(f"\n  View logs with: {B.CLI_COMMAND} image status {args.name} --logs")
 
         return 0
     except Exception as e:
@@ -762,13 +757,13 @@ def cmd_image_remove(args: argparse.Namespace) -> int:
 def main() -> int:
     """Main entry point for the CLI."""
     parser = argparse.ArgumentParser(
-        prog="sandbox",
-        description="Manage sandbox environments on DigitalOcean App Platform",
+        prog=B.CLI_COMMAND,
+        description=B.HELP_MAIN,
     )
     parser.add_argument(
         "--version",
         action="version",
-        version="app-platform-sandbox 0.1.0",
+        version=f"{B.PRODUCT_NAME} {B.PRODUCT_VERSION}",
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Commands")
@@ -776,7 +771,7 @@ def main() -> int:
     # setup command
     setup_parser = subparsers.add_parser(
         "setup",
-        help="Build and push sandbox images to your DOCR registry",
+        help=B.HELP_SETUP,
     )
     setup_parser.add_argument(
         "--registry", "-r",
@@ -814,7 +809,7 @@ def main() -> int:
     # create command
     create_parser = subparsers.add_parser(
         "create",
-        help="Create a new sandbox",
+        help=B.HELP_CREATE,
     )
     create_parser.add_argument(
         "--image", "-i",
@@ -824,7 +819,7 @@ def main() -> int:
     )
     create_parser.add_argument(
         "--name", "-n",
-        help="Name for the sandbox (auto-generated if not provided)",
+        help=B.HELP_ARG_NAME,
     )
     create_parser.add_argument(
         "--region",
@@ -854,7 +849,7 @@ def main() -> int:
     # list command
     list_parser = subparsers.add_parser(
         "list",
-        help="List all sandboxes",
+        help=B.HELP_LIST,
     )
     list_parser.add_argument(
         "--registry", "-r",
@@ -870,12 +865,12 @@ def main() -> int:
     # delete command
     delete_parser = subparsers.add_parser(
         "delete",
-        help="Delete a sandbox",
+        help=B.HELP_DELETE,
     )
     delete_parser.add_argument(
         "name",
         nargs="?",
-        help="Sandbox name to delete",
+        help=B.HELP_ARG_DELETE_NAME,
     )
     delete_parser.add_argument(
         "--registry", "-r",
@@ -900,11 +895,11 @@ def main() -> int:
     # exec command
     exec_parser = subparsers.add_parser(
         "exec",
-        help="Execute a command in a sandbox",
+        help=B.HELP_EXEC,
     )
     exec_parser.add_argument(
         "target",
-        help="Sandbox name or ID",
+        help=B.HELP_ARG_TARGET,
     )
     exec_parser.add_argument(
         "command",
@@ -931,7 +926,7 @@ def main() -> int:
     # image command group
     image_parser = subparsers.add_parser(
         "image",
-        help="Manage custom sandbox images",
+        help=B.HELP_IMAGE,
     )
     image_subparsers = image_parser.add_subparsers(dest="image_command", help="Image commands")
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a branding layer and aligns CLI/docs/workflow for separate sandbox/console variants.
> 
> - Adds `src/do_app_sandbox/branding.py` centralizing user-facing strings, CLI command, and version for variant packages
> - Refactors `cli.py` to consume branding constants for program name, help text, messages, and `--version` output; replaces hardcoded strings and standardizes outputs
> - Updates GitHub Actions `publish.yml` to publish on tag pushes (`v*`, `console-v*`), auto-detect package name from `pyproject.toml`, and include package/tag in the job summary
> - Revamps `README.md` to emphasize sandbox SDK usage, examples, related projects, and docs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e776e974a28bc70ef9d936157606fc3d9dac7f61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->