### PR TITLE
fix: enforce max_total_sandboxes limit by tracking in_use count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,9 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/do_app_sandbox"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+]

--- a/src/do_app_sandbox/manager.py
+++ b/src/do_app_sandbox/manager.py
@@ -167,6 +167,7 @@ class SandboxPool:
         # Pool state
         self._ready_queue: asyncio.Queue[_PooledSandbox] = asyncio.Queue()
         self._creating_count: int = 0
+        self._in_use_count: int = 0  # Track sandboxes that have been acquired
         self._lock = asyncio.Lock()
 
         # Tracking
@@ -193,10 +194,16 @@ class SandboxPool:
         """Number of sandboxes currently being created."""
         return self._creating_count
 
+    @property
+    def in_use_count(self) -> int:
+        """Number of sandboxes currently in use (acquired but not released)."""
+        return self._in_use_count
+
     def get_metrics(self) -> PoolMetrics:
         """Get current pool metrics."""
         self._metrics.ready = self.ready_count
         self._metrics.creating = self._creating_count
+        self._metrics.in_use = self._in_use_count
         if self._metrics.total_acquires > 0:
             self._metrics.pool_hit_rate = (
                 self._metrics.acquires_from_pool / self._metrics.total_acquires
@@ -269,11 +276,18 @@ class SandboxPool:
             latency_ms = (time.time() - start_time) * 1000
             self._record_acquire(from_pool=True, latency_ms=latency_ms)
             sandbox._from_pool = True  # Mark for external tracking
+            self._in_use_count += 1  # Track in-use sandbox
             return sandbox
 
         # Pool empty - handle based on config
         if self.config.on_empty == "fail":
             raise PoolExhaustedError(f"Pool for image '{self.image}' is exhausted")
+
+        # Check global limit before on-demand creation
+        if self._total_limit_callback and self._total_limit_callback():
+            raise PoolExhaustedError(
+                f"Global sandbox limit reached, cannot create on-demand for {self.image}"
+            )
 
         # Fall back to cold start
         logger.info(f"Pool empty for {self.image}, creating sandbox on-demand")
@@ -281,7 +295,20 @@ class SandboxPool:
         latency_ms = (time.time() - start_time) * 1000
         self._record_acquire(from_pool=False, latency_ms=latency_ms)
         sandbox._from_pool = False  # Mark for external tracking
+        self._in_use_count += 1  # Track in-use sandbox
         return sandbox
+
+    def release(self, sandbox: Sandbox) -> None:
+        """Release a sandbox back (decrement in-use count).
+
+        Call this when done with a sandbox to update the in-use count.
+        The sandbox itself should be deleted separately if not being reused.
+
+        Args:
+            sandbox: The sandbox to release
+        """
+        if self._in_use_count > 0:
+            self._in_use_count -= 1
 
     async def _try_acquire_from_pool(self) -> Optional[Sandbox]:
         """Try to get a sandbox from the pool without blocking."""
@@ -630,8 +657,11 @@ class SandboxManager:
             yield metrics.Observation(pool.creating_count, {"image": image})
 
     def _total_sandbox_count(self) -> int:
-        """Get total sandbox count across all pools."""
-        return sum(p.ready_count + p.creating_count for p in self._pools.values())
+        """Get total sandbox count across all pools (ready + creating + in_use)."""
+        return sum(
+            p.ready_count + p.creating_count + p.in_use_count
+            for p in self._pools.values()
+        )
 
     def _is_at_global_limit(self) -> bool:
         """Check if we've reached the global sandbox limit."""
@@ -709,6 +739,19 @@ class SandboxManager:
 
         pool = await self._get_or_create_pool(image)
         return await pool.acquire(timeout=timeout)
+
+    def release(self, sandbox: Sandbox, image: str) -> None:
+        """Release a sandbox (decrement in-use count for the pool).
+
+        Call this when done with a sandbox to update tracking.
+        This allows the global limit to correctly account for available capacity.
+
+        Args:
+            sandbox: The sandbox to release
+            image: The image identifier for the sandbox
+        """
+        if image in self._pools:
+            self._pools[image].release(sandbox)
 
     async def shutdown(
         self,

--- a/tests/manager_stress/PLAN_40_SANDBOX_1HR.md
+++ b/tests/manager_stress/PLAN_40_SANDBOX_1HR.md
@@ -1,0 +1,177 @@
+# 40-Sandbox 1-Hour Stress Test Plan
+
+> **Purpose**: Validate SandboxManager functionality with moderate scale
+> **Scale**: 40 concurrent sandboxes (20 Python + 20 Node)
+> **Duration**: 1 hour continuous operation
+> **Users**: 16 simulated users
+
+---
+
+## Executive Summary
+
+This plan defines a 1-hour stress test at moderate scale (40 sandboxes). This is a scaled-down version of the 500-sandbox 8-hour test, designed for quick validation and iterative development.
+
+### Key Objectives
+
+1. **Validate Core Functionality**: Acquire/release cycle works correctly
+2. **Test Pool Behavior**: Pre-warmed pools reduce latency
+3. **Verify Scale-Down**: Idle periods trigger proper cleanup
+4. **Monitor Resource Usage**: No memory/FD leaks over 1 hour
+5. **Measure Performance**: Pool hit rate, latency metrics
+
+---
+
+## Test Configuration
+
+### Pool Settings
+
+| Parameter | Python Pool | Node Pool |
+|-----------|-------------|-----------|
+| Target Ready | 5 | 5 |
+| Max Sandboxes | 20 | 20 |
+| Idle Timeout | 120s | 120s |
+| Scale-Down Delay | 60s | 60s |
+| Cooldown After Acquire | 180s | 180s |
+| Max Warm Age | 1200s (20 min) | 1200s (20 min) |
+
+### Global Settings
+
+| Parameter | Value |
+|-----------|-------|
+| Max Total Sandboxes | 40 |
+| Max Concurrent Creates | 10 |
+| Metrics Interval | 10s |
+
+### User Groups
+
+| Group | Count | Image | Pattern | Task Duration |
+|-------|-------|-------|---------|---------------|
+| python_steady | 4 | Python | Steady | 2-5 min |
+| python_burst | 4 | Python | Burst | 1-3 min |
+| node_steady | 4 | Node | Steady | 2-5 min |
+| node_burst | 4 | Node | Burst | 1-3 min |
+
+### Idle Periods (Scale-Down Testing)
+
+| Time | Duration | Purpose |
+|------|----------|---------|
+| 20 min | 5 min | First scale-down test |
+| 40 min | 5 min | Second scale-down test |
+
+---
+
+## Success Criteria
+
+### Hard Requirements (Must Pass)
+
+- [ ] 100% uptime (no crashes or unhandled exceptions)
+- [ ] >= 95% task success rate
+- [ ] No memory growth > 20% from baseline
+- [ ] Zero invariant violations (ready + creating + in_use = total)
+
+### Soft Targets (Goal)
+
+- [ ] >= 50% pool hit rate (warm sandboxes utilized)
+- [ ] < 500ms average pool hit latency
+- [ ] < 90s average cold start latency
+- [ ] Successful scale-down during idle periods
+
+---
+
+## Running the Test
+
+### Prerequisites
+
+```bash
+# Ensure DIGITALOCEAN_TOKEN is set
+export DIGITALOCEAN_TOKEN=your_token_here
+
+# Verify programs exist
+uv run python -m tests.manager_stress --validate-programs
+```
+
+### Execute Test
+
+```bash
+# Run the 1-hour test
+uv run python -m tests.manager_stress --scenario sandbox_40_1hr -v
+
+# Or with custom output directory
+uv run python -m tests.manager_stress --scenario sandbox_40_1hr -v --output-dir /path/to/output
+```
+
+### Monitor Progress
+
+Watch the logs for:
+- Pool metrics every 10 seconds
+- User acquisitions and task completions
+- Scale-down events during idle periods
+- Any errors or warnings
+
+---
+
+## Expected Timeline
+
+| Time | Phase | What Happens |
+|------|-------|--------------|
+| 0-5 min | Warm-Up | Sandboxes created, pools filling |
+| 5-20 min | Steady State | Normal operation, all users active |
+| 20-25 min | Idle Period 1 | Users pause, scale-down begins |
+| 25-40 min | Recovery | Users resume, pools refill |
+| 40-45 min | Idle Period 2 | Second scale-down test |
+| 45-60 min | Final Phase | Normal operation until completion |
+
+---
+
+## Cost Estimate
+
+- **Sandbox Cost**: 40 sandboxes x 1 hour x ~$0.02/hr = ~$0.80
+- **API Calls**: Negligible
+- **Total**: ~$0.80 per full test run
+
+---
+
+## Output Artifacts
+
+After the test completes, find these files in `tests/artifacts/stress/`:
+
+- `metrics_TIMESTAMP.csv` - Pool snapshots every 10s
+- `system_TIMESTAMP.csv` - Memory, FD, asyncio metrics every 30s
+- `tasks_TIMESTAMP.json` - Individual task results
+- `summary_TIMESTAMP.json` - Aggregate statistics
+- `report_TIMESTAMP.html` - Interactive dashboard
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Pool empty for X, creating sandbox on-demand"**
+   - Normal during initial warm-up phase
+   - Should decrease as pools fill up
+
+2. **High cold-start percentage**
+   - Check if `target_ready` is too low
+   - Verify `cooldown_after_acquire` isn't too long
+
+3. **Test fails with < 95% success**
+   - Check DO API rate limits
+   - Review task errors in JSON output
+
+4. **Memory growth detected**
+   - Check for sandbox cleanup
+   - Verify `manager.shutdown()` is called
+
+---
+
+## Comparison to 500-Sandbox Test
+
+| Aspect | 40-Sandbox | 500-Sandbox |
+|--------|------------|-------------|
+| Duration | 1 hour | 8 hours |
+| Sandboxes | 40 | 500 |
+| Users | 16 | 200 |
+| Cost | ~$0.80 | ~$240 |
+| Corner Cases | Basic | Comprehensive |
+| Leak Detection | Limited | Thorough |

--- a/tests/manager_stress/README.md
+++ b/tests/manager_stress/README.md
@@ -11,14 +11,62 @@ uv run python -m tests.manager_stress --list-scenarios
 # Run quick validation (10 min)
 uv run python -m tests.manager_stress --scenario quick_validation
 
+# Run 1-hour 40-sandbox test
+uv run python -m tests.manager_stress --scenario sandbox_40_1hr
+
 # Run 8-hour stress test (500 sandboxes)
 uv run python -m tests.manager_stress --scenario mega_stress_8hr
 
-# Dry run (mock sandboxes, no cost)
-uv run python -m tests.manager_stress --scenario mega_stress_8hr --dry-run
+# Dry run (algorithmic simulation, no real sandboxes, no cost)
+uv run python -m tests.manager_stress --scenario quick_validation --dry-run -v
 
 # Compare adaptive algorithms
 uv run python -m tests.manager_stress.algorithm_comparison
+```
+
+## Running Tests
+
+### Unit Tests (Fast, No Infrastructure)
+
+```bash
+# Run manager unit tests
+uv run pytest tests/test_manager.py -v
+
+# Run algorithmic simulator tests
+uv run pytest tests/manager_stress/test_algorithmic_simulator.py -v
+
+# Run all unit tests
+uv run pytest tests/test_manager.py tests/manager_stress/test_algorithmic_simulator.py -v
+```
+
+### Dry-Run Mode (Algorithmic Simulation)
+
+Dry-run mode uses an `AlgorithmicMockManager` that faithfully implements the same limit tracking logic as the real manager. This catches algorithmic bugs without real infrastructure.
+
+```bash
+# Quick dry-run (validates limit enforcement)
+uv run python -m tests.manager_stress --scenario quick_validation --dry-run -v
+
+# What dry-run tests:
+# - max_total_sandboxes limit enforcement
+# - ready + creating + in_use tracking
+# - Limit violation detection
+# - Pool replenishment logic
+```
+
+**Key difference from real tests**: Dry-run completes in seconds/minutes (no ~30s sandbox creation wait).
+
+### Real Sandbox Tests (Requires DIGITALOCEAN_TOKEN)
+
+```bash
+# Validate test programs exist
+uv run python -m tests.manager_stress --validate-programs
+
+# Run quick real test (10 min, ~$0.04)
+uv run python -m tests.manager_stress --scenario quick_validation -v
+
+# Run 40-sandbox 1-hour test (~$0.80)
+uv run python -m tests.manager_stress --scenario sandbox_40_1hr -v
 ```
 
 ## Folder Structure
@@ -28,6 +76,7 @@ tests/manager_stress/
 ├── README.md                    # ← You are here
 ├── PLAN.md                      # Original stress test plan
 ├── PLAN_500_SANDBOX_8HR.md      # 500-sandbox 8-hour test plan
+├── PLAN_40_SANDBOX_1HR.md       # 40-sandbox 1-hour test plan
 │
 ├── __main__.py                  # CLI entry point
 ├── config.py                    # Scenarios & configuration
@@ -36,7 +85,10 @@ tests/manager_stress/
 ├── workload_generator.py        # Program selection
 ├── metrics_collector.py         # Time-series metrics
 ├── reporter.py                  # HTML report generation
-└── algorithm_comparison.py      # Adaptive algorithm benchmarks
+├── algorithm_comparison.py      # Adaptive algorithm benchmarks
+│
+├── algorithmic_simulator.py     # AlgorithmicMockManager for dry-run
+└── test_algorithmic_simulator.py # Unit tests for simulator
 ```
 
 ## Available Scenarios
@@ -45,6 +97,7 @@ tests/manager_stress/
 |----------|----------|-------|-----------|---------|
 | `quick_validation` | 10 min | 4 | 8 | Smoke test |
 | `burst_test` | 30 min | 20 | 30 | Pool exhaustion |
+| `sandbox_40_1hr` | 1 hr | 16 | 40 | Medium scale validation |
 | `steady_state` | 1 hr | 24 | 40 | Sustained load |
 | `scale_cycle` | 90 min | 30 | 40 | Scale up/down |
 | `full_stress` | 2h 10m | 50 | 50 | Full stress |
@@ -119,8 +172,10 @@ tests/artifacts/stress/
 
 | Scenario | Sandboxes | Duration | Est. Cost |
 |----------|-----------|----------|-----------|
+| Any scenario (dry-run) | 0 | seconds | $0 |
 | quick_validation | 8 | 10 min | ~$0.04 |
+| sandbox_40_1hr | 40 | 1 hr | ~$0.80 |
 | full_stress | 50 | 2 hr | ~$3 |
 | mega_stress_8hr | 500 | 8 hr | ~$120 |
 
-*Based on $0.03/sandbox/hour*
+*Based on $0.03/sandbox/hour. Dry-run mode uses no real sandboxes.*

--- a/tests/manager_stress/algorithmic_simulator.py
+++ b/tests/manager_stress/algorithmic_simulator.py
@@ -1,0 +1,486 @@
+"""
+Algorithmic Simulator for SandboxManager stress tests.
+
+This module provides a MockSandboxManager that faithfully implements the same
+limit tracking and pool logic as the real SandboxManager, enabling dry-run tests
+that actually catch algorithmic bugs.
+
+Key differences from the basic mock in orchestrator.py:
+1. Actually enforces max_total_sandboxes limit
+2. Tracks ready, creating, in_use counts accurately
+3. Simulates acquire/release lifecycle
+4. Detects and reports limit violations
+5. Provides invariant checking
+
+The simulator is designed to catch bugs like the _total_sandbox_count bug where
+in_use sandboxes were not counted, causing limit violations.
+"""
+
+import asyncio
+import logging
+import random
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxState(Enum):
+    """State of a simulated sandbox."""
+    CREATING = "creating"
+    READY = "ready"  # In pool, available for acquisition
+    IN_USE = "in_use"  # Acquired by a user
+    DELETED = "deleted"
+
+
+@dataclass
+class SimulatedSandbox:
+    """Represents a sandbox in the simulation."""
+    sandbox_id: str
+    image: str
+    state: SandboxState
+    created_at: float = field(default_factory=time.time)
+    acquired_at: Optional[float] = None
+    _from_pool: bool = False
+
+    @property
+    def age(self) -> float:
+        return time.time() - self.created_at
+
+
+@dataclass
+class PoolStats:
+    """Statistics for a single pool."""
+    ready: int = 0
+    creating: int = 0
+    in_use: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.ready + self.creating + self.in_use
+
+
+@dataclass
+class LimitViolation:
+    """Records a limit violation event."""
+    timestamp: float
+    violation_type: str
+    limit_name: str
+    limit_value: int
+    actual_value: int
+    details: str
+
+
+class SimulatedPool:
+    """
+    Simulates a SandboxPool for a single image.
+
+    This implements the same logic as the real SandboxPool but without
+    actual infrastructure, allowing algorithm testing in dry-run mode.
+    """
+
+    def __init__(
+        self,
+        image: str,
+        target_ready: int,
+        max_sandboxes: int,
+        global_limit_callback: Optional[callable] = None,
+        create_delay: tuple[float, float] = (1.0, 5.0),  # Simulated creation time
+    ):
+        self.image = image
+        self.target_ready = target_ready
+        self.max_sandboxes = max_sandboxes
+        self._global_limit_callback = global_limit_callback
+        self._create_delay = create_delay
+
+        # State tracking
+        self._sandboxes: Dict[str, SimulatedSandbox] = {}
+        self._ready_queue: List[str] = []  # IDs of ready sandboxes
+        self._creating_count: int = 0
+        self._in_use_set: Set[str] = set()  # IDs of in-use sandboxes
+
+        # Lock for thread safety
+        self._lock = asyncio.Lock()
+
+        # Metrics
+        self._total_acquires: int = 0
+        self._pool_hits: int = 0
+        self._cold_starts: int = 0
+        self._limit_violations: List[LimitViolation] = []
+
+        # Background task
+        self._replenish_task: Optional[asyncio.Task] = None
+        self._shutdown: bool = False
+
+        # Counter for unique IDs
+        self._id_counter: int = 0
+
+    @property
+    def ready_count(self) -> int:
+        return len(self._ready_queue)
+
+    @property
+    def creating_count(self) -> int:
+        return self._creating_count
+
+    @property
+    def in_use_count(self) -> int:
+        return len(self._in_use_set)
+
+    @property
+    def total_count(self) -> int:
+        return self.ready_count + self.creating_count + self.in_use_count
+
+    def get_stats(self) -> PoolStats:
+        return PoolStats(
+            ready=self.ready_count,
+            creating=self.creating_count,
+            in_use=self.in_use_count,
+        )
+
+    async def start(self):
+        """Start background replenishment."""
+        self._shutdown = False
+        self._replenish_task = asyncio.create_task(self._replenish_loop())
+
+    async def stop(self):
+        """Stop and clean up."""
+        self._shutdown = True
+        if self._replenish_task:
+            self._replenish_task.cancel()
+            try:
+                await self._replenish_task
+            except asyncio.CancelledError:
+                pass
+
+    async def acquire(self, timeout: Optional[float] = None) -> SimulatedSandbox:
+        """Acquire a sandbox from the pool or create on-demand."""
+        self._total_acquires += 1
+
+        # Try to get from pool first
+        async with self._lock:
+            if self._ready_queue:
+                sandbox_id = self._ready_queue.pop(0)
+                sandbox = self._sandboxes[sandbox_id]
+                sandbox.state = SandboxState.IN_USE
+                sandbox.acquired_at = time.time()
+                sandbox._from_pool = True
+                self._in_use_set.add(sandbox_id)
+                self._pool_hits += 1
+                logger.debug(f"[{self.image}] Acquired from pool: {sandbox_id}")
+                return sandbox
+
+        # Check global limit before on-demand creation
+        if self._global_limit_callback and self._global_limit_callback():
+            raise Exception(f"Global sandbox limit reached, cannot create on-demand for {self.image}")
+
+        # Cold start - create on-demand
+        self._cold_starts += 1
+        sandbox = await self._create_sandbox()
+
+        async with self._lock:
+            sandbox.state = SandboxState.IN_USE
+            sandbox.acquired_at = time.time()
+            sandbox._from_pool = False
+            self._in_use_set.add(sandbox.sandbox_id)
+
+        logger.debug(f"[{self.image}] Created on-demand: {sandbox.sandbox_id}")
+        return sandbox
+
+    def release(self, sandbox: SimulatedSandbox):
+        """Release a sandbox (decrement in-use count)."""
+        if sandbox.sandbox_id in self._in_use_set:
+            self._in_use_set.discard(sandbox.sandbox_id)
+            sandbox.state = SandboxState.DELETED
+            logger.debug(f"[{self.image}] Released: {sandbox.sandbox_id}")
+        else:
+            logger.warning(f"[{self.image}] Tried to release unknown sandbox: {sandbox.sandbox_id}")
+
+    async def _create_sandbox(self) -> SimulatedSandbox:
+        """Simulate creating a sandbox."""
+        async with self._lock:
+            self._creating_count += 1
+
+        try:
+            # Simulate creation delay
+            delay = random.uniform(*self._create_delay)
+            await asyncio.sleep(delay)
+
+            self._id_counter += 1
+            sandbox_id = f"{self.image}-sim-{self._id_counter}"
+            sandbox = SimulatedSandbox(
+                sandbox_id=sandbox_id,
+                image=self.image,
+                state=SandboxState.READY,
+            )
+            self._sandboxes[sandbox_id] = sandbox
+            return sandbox
+        finally:
+            async with self._lock:
+                self._creating_count -= 1
+
+    async def _replenish_loop(self):
+        """Background loop to maintain target pool size."""
+        while not self._shutdown:
+            try:
+                await self._replenish_once()
+                await asyncio.sleep(0.5)  # Check frequently
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"[{self.image}] Replenish error: {e}")
+                await asyncio.sleep(1)
+
+    async def _replenish_once(self):
+        """Check if we need to create more sandboxes."""
+        current = self.ready_count + self.creating_count
+
+        # Check if we're below target
+        if current >= self.target_ready:
+            return
+
+        # Check pool limit
+        if self.total_count >= self.max_sandboxes:
+            return
+
+        # Check global limit
+        if self._global_limit_callback and self._global_limit_callback():
+            logger.debug(f"[{self.image}] Global limit reached, not creating")
+            return
+
+        # Create one sandbox in background
+        asyncio.create_task(self._create_and_add_to_pool())
+
+    async def _create_and_add_to_pool(self):
+        """Create a sandbox and add to ready queue."""
+        try:
+            sandbox = await self._create_sandbox()
+            if not self._shutdown:
+                async with self._lock:
+                    self._ready_queue.append(sandbox.sandbox_id)
+                    logger.debug(f"[{self.image}] Added to pool: {sandbox.sandbox_id}, now {self.ready_count} ready")
+        except Exception as e:
+            logger.error(f"[{self.image}] Failed to create for pool: {e}")
+
+
+class AlgorithmicMockManager:
+    """
+    Mock SandboxManager that faithfully implements the algorithm.
+
+    This is designed for comprehensive dry-run testing. It enforces the same
+    limits and tracks state exactly as the real SandboxManager would, allowing
+    algorithmic bugs to be caught without real infrastructure.
+
+    Key features:
+    - Enforces max_total_sandboxes limit
+    - Tracks ready + creating + in_use for global limit
+    - Detects and logs limit violations
+    - Provides detailed statistics for debugging
+    """
+
+    def __init__(
+        self,
+        pools: Dict[str, Dict[str, Any]],
+        max_total_sandboxes: Optional[int] = None,
+        max_concurrent_creates: int = 10,
+        create_delay: tuple[float, float] = (0.5, 2.0),
+    ):
+        """
+        Initialize the mock manager.
+
+        Args:
+            pools: Dict mapping image name to pool config dict with:
+                - target_ready: int
+                - max_sandboxes: int
+            max_total_sandboxes: Global limit (None = unlimited)
+            max_concurrent_creates: Max parallel creates (simulated)
+            create_delay: (min, max) seconds for simulated creation
+        """
+        self._max_total = max_total_sandboxes
+        self._create_delay = create_delay
+
+        # Create pools
+        self._pools: Dict[str, SimulatedPool] = {}
+        for image, config in pools.items():
+            self._pools[image] = SimulatedPool(
+                image=image,
+                target_ready=config.get('target_ready', 5),
+                max_sandboxes=config.get('max_sandboxes', 20),
+                global_limit_callback=self._is_at_global_limit,
+                create_delay=create_delay,
+            )
+
+        # Violation tracking
+        self._violations: List[LimitViolation] = []
+        self._max_observed_total: int = 0
+
+        # State
+        self._started = False
+        self._shutdown = False
+
+    def _total_sandbox_count(self) -> int:
+        """Get total sandbox count across all pools (ready + creating + in_use)."""
+        total = sum(
+            p.ready_count + p.creating_count + p.in_use_count
+            for p in self._pools.values()
+        )
+        # Track max observed
+        if total > self._max_observed_total:
+            self._max_observed_total = total
+        return total
+
+    def _is_at_global_limit(self) -> bool:
+        """Check if we've reached the global sandbox limit."""
+        if self._max_total is None:
+            return False
+        current = self._total_sandbox_count()
+        at_limit = current >= self._max_total
+
+        # Check for violation (if we somehow exceeded)
+        if current > self._max_total:
+            violation = LimitViolation(
+                timestamp=time.time(),
+                violation_type="exceeded",
+                limit_name="max_total_sandboxes",
+                limit_value=self._max_total,
+                actual_value=current,
+                details=self._get_pool_breakdown(),
+            )
+            self._violations.append(violation)
+            logger.error(f"LIMIT VIOLATION: {current} > {self._max_total}")
+            logger.error(f"  Breakdown: {self._get_pool_breakdown()}")
+
+        return at_limit
+
+    def _get_pool_breakdown(self) -> str:
+        """Get detailed breakdown of pool counts."""
+        parts = []
+        for image, pool in self._pools.items():
+            parts.append(f"{image}(r={pool.ready_count},c={pool.creating_count},u={pool.in_use_count})")
+        return ", ".join(parts)
+
+    async def start(self):
+        """Start the manager and all pools."""
+        if self._started:
+            return
+        self._started = True
+        self._shutdown = False
+
+        for pool in self._pools.values():
+            await pool.start()
+
+        logger.info(f"AlgorithmicMockManager started with {len(self._pools)} pools")
+        logger.info(f"  max_total_sandboxes: {self._max_total}")
+
+    async def shutdown(self, timeout: float = 30.0):
+        """Shutdown the manager."""
+        if self._shutdown:
+            return
+        self._shutdown = True
+
+        for pool in self._pools.values():
+            await pool.stop()
+
+        self._started = False
+        logger.info("AlgorithmicMockManager shutdown")
+
+        # Report any violations
+        if self._violations:
+            logger.error(f"DETECTED {len(self._violations)} LIMIT VIOLATIONS:")
+            for v in self._violations:
+                logger.error(f"  {v.violation_type}: {v.actual_value} > {v.limit_value}")
+
+    async def acquire(self, image: str, timeout: Optional[float] = None) -> SimulatedSandbox:
+        """Acquire a sandbox for the given image."""
+        if not self._started:
+            raise RuntimeError("Manager not started")
+        if self._shutdown:
+            raise RuntimeError("Manager is shutting down")
+
+        if image not in self._pools:
+            raise ValueError(f"Unknown image: {image}")
+
+        # Invariant check before acquire
+        self._check_invariants("pre-acquire")
+
+        sandbox = await self._pools[image].acquire(timeout=timeout)
+
+        # Invariant check after acquire
+        self._check_invariants("post-acquire")
+
+        return sandbox
+
+    def release(self, sandbox: SimulatedSandbox, image: str):
+        """Release a sandbox back."""
+        if image in self._pools:
+            self._pools[image].release(sandbox)
+
+        # Invariant check after release
+        self._check_invariants("post-release")
+
+    def _check_invariants(self, context: str):
+        """Check invariants and log violations."""
+        total = self._total_sandbox_count()
+
+        if self._max_total is not None and total > self._max_total:
+            logger.error(f"INVARIANT VIOLATION at {context}: total={total} > max={self._max_total}")
+            logger.error(f"  Breakdown: {self._get_pool_breakdown()}")
+
+    def metrics(self) -> Dict[str, PoolStats]:
+        """Get current metrics for all pools."""
+        return {image: pool.get_stats() for image, pool in self._pools.items()}
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get detailed statistics for metrics collection."""
+        stats = {}
+        for image, pool in self._pools.items():
+            stats[f'{image}_ready'] = pool.ready_count
+            stats[f'{image}_creating'] = pool.creating_count
+            stats[f'{image}_in_use'] = pool.in_use_count
+
+        stats['total_sandboxes'] = self._total_sandbox_count()
+        stats['max_observed'] = self._max_observed_total
+        stats['violations'] = len(self._violations)
+        return stats
+
+    def get_violations(self) -> List[LimitViolation]:
+        """Get all recorded violations."""
+        return self._violations.copy()
+
+    def get_max_observed(self) -> int:
+        """Get the maximum total sandboxes observed."""
+        return self._max_observed_total
+
+
+def create_algorithmic_mock(scenario_config) -> AlgorithmicMockManager:
+    """
+    Create an AlgorithmicMockManager from a scenario config.
+
+    Args:
+        scenario_config: ScenarioConfig from config.py
+
+    Returns:
+        Configured AlgorithmicMockManager
+    """
+    config = scenario_config.test_config
+
+    pools = {
+        'python': {
+            'target_ready': config.python_pool.target_ready,
+            'max_sandboxes': config.python_pool.max_sandboxes,
+        },
+        'node': {
+            'target_ready': config.node_pool.target_ready,
+            'max_sandboxes': config.node_pool.max_sandboxes,
+        },
+    }
+
+    return AlgorithmicMockManager(
+        pools=pools,
+        max_total_sandboxes=config.max_total_sandboxes,
+        max_concurrent_creates=config.max_concurrent_creates,
+        # Faster delays for dry-run testing
+        create_delay=(0.1, 0.5),
+    )

--- a/tests/manager_stress/config.py
+++ b/tests/manager_stress/config.py
@@ -546,6 +546,67 @@ def get_scale_boundary() -> ScenarioConfig:
     )
 
 
+def get_sandbox_40_1hr() -> ScenarioConfig:
+    """40-sandbox test for 1 hour (20 Python, 20 Node)."""
+    return ScenarioConfig(
+        name="sandbox_40_1hr",
+        description="1-hour test - 40 sandboxes (20 Python, 20 Node), 16 users",
+        duration_seconds=3600,  # 1 hour
+        user_groups=[
+            # Python users - steady load
+            UserGroupConfig(
+                name="python_steady",
+                count=4,
+                image=ImageType.PYTHON,
+                pattern=LoadPattern.STEADY,
+                task_duration_range=(120, 300),  # 2-5 min
+                categories=["compute", "io", "mixed"],
+            ),
+            # Python users - burst
+            UserGroupConfig(
+                name="python_burst",
+                count=4,
+                image=ImageType.PYTHON,
+                pattern=LoadPattern.BURST,
+                task_duration_range=(60, 180),  # 1-3 min
+                categories=["compute", "io"],
+            ),
+            # Node users - steady load
+            UserGroupConfig(
+                name="node_steady",
+                count=4,
+                image=ImageType.NODE,
+                pattern=LoadPattern.STEADY,
+                task_duration_range=(120, 300),  # 2-5 min
+                categories=["compute", "io", "mixed"],
+            ),
+            # Node users - burst
+            UserGroupConfig(
+                name="node_burst",
+                count=4,
+                image=ImageType.NODE,
+                pattern=LoadPattern.BURST,
+                task_duration_range=(60, 180),  # 1-3 min
+                categories=["async", "io"],
+            ),
+        ],
+        test_config=TestConfig(
+            python_pool=PoolConfig(ImageType.PYTHON, target_ready=5, max_sandboxes=20),
+            node_pool=PoolConfig(ImageType.NODE, target_ready=5, max_sandboxes=20),
+            max_total_sandboxes=40,
+            max_concurrent_creates=10,
+            idle_timeout=120,
+            scale_down_delay=60,
+            cooldown_after_acquire=180,
+            max_warm_age=1200,  # 20 min max age
+        ),
+        idle_periods=[
+            (1200, 300),   # 5 min idle at 20 min mark
+            (2400, 300),   # 5 min idle at 40 min mark
+        ],
+    )
+
+
 SCENARIOS = {
     "quick_validation": get_quick_validation,
     "burst_test": get_burst_test,
@@ -555,6 +616,7 @@ SCENARIOS = {
     "mega_stress_8hr": get_mega_stress_8hr,
     "corner_case_blitz": get_corner_case_blitz,
     "scale_boundary": get_scale_boundary,
+    "sandbox_40_1hr": get_sandbox_40_1hr,
 }
 
 

--- a/tests/manager_stress/orchestrator.py
+++ b/tests/manager_stress/orchestrator.py
@@ -30,6 +30,7 @@ from .metrics_collector import MetricsCollector
 from .workload_generator import WorkloadGenerator
 from .user_simulator import UserSimulator, run_user_group
 from .reporter import generate_report
+from .algorithmic_simulator import AlgorithmicMockManager, create_algorithmic_mock
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,9 @@ class StressTestOrchestrator:
         if manager is not None:
             self.manager = manager
         elif dry_run:
-            self.manager = MockSandboxManager()
+            # Use algorithmic mock that faithfully implements limit tracking
+            self.manager = create_algorithmic_mock(scenario)
+            logger.info("Using AlgorithmicMockManager for dry-run (enforces real limits)")
         else:
             self.manager = self._create_manager()
 
@@ -174,6 +177,20 @@ class StressTestOrchestrator:
                 logger.info("Shutting down manager...")
                 await self.manager.shutdown()
 
+        # Report violations from algorithmic mock
+        violations = []
+        max_observed = 0
+        if hasattr(self.manager, 'get_violations'):
+            violations = self.manager.get_violations()
+            max_observed = self.manager.get_max_observed()
+            if violations:
+                logger.error(f"DETECTED {len(violations)} LIMIT VIOLATIONS!")
+                for v in violations:
+                    logger.error(f"  {v.violation_type}: {v.actual_value} > {v.limit_value}")
+                    logger.error(f"    at {v.timestamp}: {v.details}")
+            else:
+                logger.info(f"No limit violations detected (max observed: {max_observed}/{self.scenario.test_config.max_total_sandboxes})")
+
         # Generate reports
         logger.info("Generating reports...")
         files = self.metrics.save_all()
@@ -191,13 +208,22 @@ class StressTestOrchestrator:
         logger.info(f"Pool hit rate: {summary.pool_hit_rate:.1f}%")
         logger.info(f"Avg acquire latency: {summary.avg_acquire_latency_ms:.0f}ms")
         logger.info(f"Max concurrent: {summary.max_concurrent_sandboxes}")
+        if max_observed > 0:
+            logger.info(f"Max observed total: {max_observed}/{self.scenario.test_config.max_total_sandboxes}")
+        if violations:
+            logger.error(f"LIMIT VIOLATIONS: {len(violations)}")
         logger.info("=" * 60)
         logger.info(f"Report: {report_path}")
 
+        # Test passes if: success rate >= 95% AND no limit violations
+        test_passed = summary.success_rate >= 95.0 and len(violations) == 0
+
         return {
-            'success': summary.success_rate >= 95.0,
+            'success': test_passed,
             'summary': summary,
             'files': files,
+            'violations': violations,
+            'max_observed': max_observed,
         }
 
     async def _run_test(self, end_time: float):

--- a/tests/manager_stress/test_algorithmic_simulator.py
+++ b/tests/manager_stress/test_algorithmic_simulator.py
@@ -1,0 +1,387 @@
+"""
+Unit tests for the algorithmic simulator.
+
+These tests verify that:
+1. The simulator correctly enforces limits
+2. It catches bugs like the _total_sandbox_count bug
+3. Dry-run mode provides reliable algorithm validation
+
+Run with: uv run pytest tests/manager_stress/test_algorithmic_simulator.py
+Or quick test: uv run python tests/manager_stress/test_algorithmic_simulator.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Make pytest optional for direct execution
+try:
+    import pytest
+except ImportError:
+    # Create a dummy pytest module for direct execution
+    class DummyPytest:
+        class mark:
+            @staticmethod
+            def asyncio(func):
+                return func
+    pytest = DummyPytest()
+
+# Handle both package import and direct execution
+try:
+    from .algorithmic_simulator import (
+        AlgorithmicMockManager,
+        SimulatedPool,
+        SimulatedSandbox,
+        SandboxState,
+    )
+except ImportError:
+    # Direct execution - add parent to path
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+    from tests.manager_stress.algorithmic_simulator import (
+        AlgorithmicMockManager,
+        SimulatedPool,
+        SimulatedSandbox,
+        SandboxState,
+    )
+
+
+class TestSimulatedPool:
+    """Tests for individual pool behavior."""
+
+    @pytest.mark.asyncio
+    async def test_pool_counts_in_use(self):
+        """Verify pool tracks in_use count correctly."""
+        pool = SimulatedPool(
+            image="test",
+            target_ready=2,
+            max_sandboxes=5,
+            create_delay=(0.01, 0.02),
+        )
+
+        await pool.start()
+        try:
+            # Initial state
+            assert pool.ready_count == 0
+            assert pool.in_use_count == 0
+            assert pool.total_count == 0
+
+            # Acquire a sandbox
+            sandbox = await pool.acquire()
+            assert pool.in_use_count == 1
+            assert sandbox.state == SandboxState.IN_USE
+
+            # Release it
+            pool.release(sandbox)
+            assert pool.in_use_count == 0
+        finally:
+            await pool.stop()
+
+    @pytest.mark.asyncio
+    async def test_pool_total_includes_all_states(self):
+        """Verify total_count = ready + creating + in_use."""
+        pool = SimulatedPool(
+            image="test",
+            target_ready=3,
+            max_sandboxes=10,
+            create_delay=(0.01, 0.02),
+        )
+
+        await pool.start()
+        try:
+            # Wait for some sandboxes to become ready
+            await asyncio.sleep(0.2)
+
+            # Acquire some sandboxes
+            acquired = []
+            for _ in range(min(2, pool.ready_count)):
+                s = await pool.acquire()
+                acquired.append(s)
+
+            # Verify invariant
+            total = pool.ready_count + pool.creating_count + pool.in_use_count
+            assert pool.total_count == total, f"total_count mismatch: {pool.total_count} != {total}"
+            assert pool.in_use_count == len(acquired)
+
+            # Release and verify
+            for s in acquired:
+                pool.release(s)
+            assert pool.in_use_count == 0
+        finally:
+            await pool.stop()
+
+
+class TestAlgorithmicMockManager:
+    """Tests for the full manager."""
+
+    @pytest.mark.asyncio
+    async def test_global_limit_enforced(self):
+        """Verify max_total_sandboxes is enforced."""
+        manager = AlgorithmicMockManager(
+            pools={
+                'python': {'target_ready': 2, 'max_sandboxes': 5},
+                'node': {'target_ready': 2, 'max_sandboxes': 5},
+            },
+            max_total_sandboxes=6,  # Less than sum of per-pool limits
+            create_delay=(0.01, 0.02),
+        )
+
+        await manager.start()
+        try:
+            acquired = []
+
+            # Acquire up to the limit
+            for _ in range(6):
+                try:
+                    image = 'python' if len(acquired) % 2 == 0 else 'node'
+                    s = await manager.acquire(image)
+                    acquired.append((s, image))
+                except Exception:
+                    break
+
+            # Try to acquire one more - should fail
+            with pytest.raises(Exception, match="Global sandbox limit reached"):
+                await manager.acquire('python')
+
+            # Verify no violations
+            assert len(manager.get_violations()) == 0
+            assert manager._total_sandbox_count() <= 6
+
+        finally:
+            await manager.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_in_use_counted_in_total(self):
+        """Verify in_use sandboxes are counted in _total_sandbox_count()."""
+        manager = AlgorithmicMockManager(
+            pools={
+                'python': {'target_ready': 0, 'max_sandboxes': 10},
+            },
+            max_total_sandboxes=5,
+            create_delay=(0.01, 0.02),
+        )
+
+        await manager.start()
+        try:
+            acquired = []
+
+            # Acquire 5 sandboxes
+            for i in range(5):
+                s = await manager.acquire('python')
+                acquired.append(s)
+
+                # Verify count includes in_use
+                total = manager._total_sandbox_count()
+                assert total == i + 1, f"After acquire {i+1}, total should be {i+1}, got {total}"
+
+            # Verify we're at the limit
+            assert manager._total_sandbox_count() == 5
+            assert manager._is_at_global_limit()
+
+            # Release one and verify count drops
+            manager.release(acquired[0], 'python')
+            assert manager._total_sandbox_count() == 4
+            assert not manager._is_at_global_limit()
+
+        finally:
+            await manager.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_detects_limit_violations(self):
+        """Verify violations are detected and recorded."""
+        manager = AlgorithmicMockManager(
+            pools={
+                'python': {'target_ready': 0, 'max_sandboxes': 10},
+            },
+            max_total_sandboxes=3,
+            create_delay=(0.01, 0.02),
+        )
+
+        await manager.start()
+        try:
+            # Normal acquisitions
+            acquired = []
+            for _ in range(3):
+                s = await manager.acquire('python')
+                acquired.append(s)
+
+            # This should fail (at limit)
+            with pytest.raises(Exception):
+                await manager.acquire('python')
+
+            # No violations should be recorded (limit was enforced)
+            assert len(manager.get_violations()) == 0
+
+        finally:
+            await manager.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_release_frees_capacity(self):
+        """Verify releasing a sandbox frees capacity for new ones."""
+        manager = AlgorithmicMockManager(
+            pools={
+                'python': {'target_ready': 0, 'max_sandboxes': 10},
+            },
+            max_total_sandboxes=2,
+            create_delay=(0.01, 0.02),
+        )
+
+        await manager.start()
+        try:
+            # Acquire to limit
+            s1 = await manager.acquire('python')
+            s2 = await manager.acquire('python')
+
+            # Can't acquire more
+            with pytest.raises(Exception):
+                await manager.acquire('python')
+
+            # Release one
+            manager.release(s1, 'python')
+
+            # Now we can acquire again
+            s3 = await manager.acquire('python')
+            assert s3 is not None
+
+        finally:
+            await manager.shutdown()
+
+
+class TestBugDetection:
+    """
+    Tests that verify the simulator would catch the _total_sandbox_count bug.
+
+    The original bug was that _total_sandbox_count() only counted ready + creating,
+    not in_use sandboxes. This caused the global limit to not be enforced.
+    """
+
+    @pytest.mark.asyncio
+    async def test_would_catch_missing_in_use_tracking(self):
+        """
+        Simulate what happens if in_use is not tracked.
+
+        This test demonstrates that with proper tracking, the limit is enforced.
+        The original bug would have allowed unlimited acquisitions.
+        """
+        manager = AlgorithmicMockManager(
+            pools={
+                'python': {'target_ready': 0, 'max_sandboxes': 100},
+                'node': {'target_ready': 0, 'max_sandboxes': 100},
+            },
+            max_total_sandboxes=10,  # Limit should be enforced
+            create_delay=(0.01, 0.02),
+        )
+
+        await manager.start()
+        try:
+            acquired = []
+
+            # Try to acquire many sandboxes
+            for i in range(20):
+                try:
+                    image = 'python' if i % 2 == 0 else 'node'
+                    s = await manager.acquire(image)
+                    acquired.append((s, image))
+                except Exception as e:
+                    # Should hit limit at 10
+                    assert len(acquired) == 10, f"Expected to hit limit at 10, but got {len(acquired)}"
+                    break
+
+            # Verify we stopped at the limit
+            assert len(acquired) == 10
+            assert manager._total_sandbox_count() == 10
+
+            # The original bug would have allowed all 20 acquisitions
+            # because in_use wasn't counted
+
+        finally:
+            await manager.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_acquisitions_respect_limit(self):
+        """Test that concurrent acquisitions respect the limit."""
+        manager = AlgorithmicMockManager(
+            pools={
+                'python': {'target_ready': 0, 'max_sandboxes': 50},
+                'node': {'target_ready': 0, 'max_sandboxes': 50},
+            },
+            max_total_sandboxes=8,
+            create_delay=(0.05, 0.1),
+        )
+
+        await manager.start()
+        try:
+            async def acquire_many(image: str, count: int):
+                acquired = []
+                for _ in range(count):
+                    try:
+                        s = await manager.acquire(image)
+                        acquired.append(s)
+                    except Exception:
+                        break
+                return acquired
+
+            # Launch concurrent acquisitions
+            results = await asyncio.gather(
+                acquire_many('python', 10),
+                acquire_many('node', 10),
+            )
+
+            total_acquired = len(results[0]) + len(results[1])
+
+            # Should not exceed the limit
+            assert total_acquired <= 8, f"Acquired {total_acquired} > limit 8"
+            assert manager._total_sandbox_count() <= 8
+
+            # Should have no violations
+            assert len(manager.get_violations()) == 0
+
+        finally:
+            await manager.shutdown()
+
+
+# Quick verification that can be run directly
+if __name__ == "__main__":
+    async def quick_test():
+        print("Running quick algorithmic simulator test...")
+
+        manager = AlgorithmicMockManager(
+            pools={
+                'python': {'target_ready': 2, 'max_sandboxes': 10},
+                'node': {'target_ready': 2, 'max_sandboxes': 10},
+            },
+            max_total_sandboxes=8,
+            create_delay=(0.01, 0.02),
+        )
+
+        await manager.start()
+        try:
+            acquired = []
+            images = ['python', 'node'] * 10
+
+            for image in images:
+                try:
+                    s = await manager.acquire(image)
+                    acquired.append((s, image))
+                    total = manager._total_sandbox_count()
+                    print(f"Acquired {len(acquired)}: total={total}")
+                except Exception as e:
+                    print(f"Limit reached after {len(acquired)}: {e}")
+                    break
+
+            print(f"\nFinal stats:")
+            print(f"  Acquired: {len(acquired)}")
+            print(f"  Total count: {manager._total_sandbox_count()}")
+            print(f"  Max observed: {manager.get_max_observed()}")
+            print(f"  Violations: {len(manager.get_violations())}")
+
+            if len(manager.get_violations()) > 0:
+                print("\nVIOLATIONS DETECTED - BUG FOUND!")
+                for v in manager.get_violations():
+                    print(f"  {v}")
+            else:
+                print("\nNo violations - limit enforcement working correctly")
+
+        finally:
+            await manager.shutdown()
+
+    asyncio.run(quick_test())

--- a/tests/manager_stress/user_simulator.py
+++ b/tests/manager_stress/user_simulator.py
@@ -251,6 +251,14 @@ class UserSimulator:
 
     async def _release_sandbox(self, sandbox: Any):
         """Release a sandbox - sandboxes are single-use, so we delete them."""
+        # First, notify the manager that we're releasing (to update in_use_count)
+        image_name = self.group.image.value
+        if hasattr(self.manager, 'release'):
+            try:
+                self.manager.release(sandbox, image_name)
+            except Exception as e:
+                logger.warning(f"Failed to call manager.release: {e}")
+
         # SandboxManager sandboxes are single-use - delete when done
         # The pool replenishes by creating new sandboxes
         if hasattr(sandbox, 'delete'):
@@ -259,8 +267,6 @@ class UserSimulator:
                 await asyncio.to_thread(sandbox.delete)
             except Exception as e:
                 logger.warning(f"Failed to delete sandbox: {e}")
-        elif hasattr(self.manager, 'release'):
-            await self.manager.release(sandbox)
         elif hasattr(sandbox, 'close'):
             await sandbox.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10.12"
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.9"
 source = { registry = "https://pypi.org/simple" }
@@ -58,6 +67,12 @@ spaces = [
     { name = "boto3" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.34.0" },
@@ -66,6 +81,12 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
 ]
 provides-extras = ["dev", "spaces", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+]
 
 [[package]]
 name = "exceptiongroup"
@@ -161,6 +182,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #10

- **Bug fixed**: `_total_sandbox_count()` only counted `ready + creating`, not `in_use` sandboxes, causing the global limit to be bypassed
- **Core fix**: Added `in_use_count` tracking and `release()` method
- **Comprehensive dry-run testing**: Added `AlgorithmicMockManager` that faithfully implements limit tracking for catching algorithmic bugs without real infrastructure
- **New scenario**: `sandbox_40_1hr` (40 sandboxes, 1 hour, 16 users)

## Test plan

- [x] Unit tests pass: `uv run pytest tests/test_manager.py -v` (31 tests)
- [x] Algorithmic simulator tests pass: `uv run pytest tests/manager_stress/test_algorithmic_simulator.py -v` (8 tests)
- [x] Dry-run validates limit enforcement (max_observed never exceeds limit)
- [ ] Real sandbox test with `sandbox_40_1hr` scenario

## Files changed

| File | Change |
|------|--------|
| `src/do_app_sandbox/manager.py` | Added `in_use_count` tracking, `release()` method |
| `tests/manager_stress/algorithmic_simulator.py` | New: comprehensive mock for dry-run |
| `tests/manager_stress/test_algorithmic_simulator.py` | New: unit tests for simulator |
| `tests/manager_stress/config.py` | Added `sandbox_40_1hr` scenario |
| `tests/manager_stress/orchestrator.py` | Use algorithmic mock in dry-run |
| `tests/manager_stress/user_simulator.py` | Call `manager.release()` |
| `tests/manager_stress/README.md` | Updated with test instructions |

🤖 Generated with [Claude Code](https://claude.com/claude-code)