### PR TITLE
Fix: SandboxManager pool race conditions and shutdown edge cases

### DIFF
--- a/src/do_app_sandbox/manager.py
+++ b/src/do_app_sandbox/manager.py
@@ -183,6 +183,7 @@ class SandboxPool:
         # Background tasks
         self._replenish_task: Optional[asyncio.Task] = None
         self._health_task: Optional[asyncio.Task] = None
+        self._creation_tasks: set[asyncio.Task] = set()  # Track in-flight creation tasks
 
     @property
     def ready_count(self) -> int:
@@ -217,6 +218,7 @@ class SandboxPool:
     async def start(self) -> None:
         """Start background tasks for this pool."""
         self._shutdown = False
+        self._is_active = True  # Start active so pool pre-warms immediately
         self._replenish_task = asyncio.create_task(self._replenish_loop())
         if self.config.health_check_interval > 0:
             self._health_task = asyncio.create_task(self._health_check_loop())
@@ -240,7 +242,16 @@ class SandboxPool:
             except asyncio.CancelledError:
                 pass
 
-        # Destroy all pooled sandboxes
+        # Cancel in-flight creation tasks and wait for them to complete
+        # This ensures we don't wait indefinitely for long-running sandbox creations
+        if self._creation_tasks:
+            logger.debug(f"Cancelling {len(self._creation_tasks)} in-flight creation tasks")
+            for task in self._creation_tasks:
+                task.cancel()
+            # Wait for cancellation to complete - return_exceptions captures CancelledError
+            await asyncio.gather(*self._creation_tasks, return_exceptions=True)
+
+        # Destroy all pooled sandboxes (any that slipped through before shutdown flag was set)
         await self._drain_pool()
 
     async def _drain_pool(self) -> None:
@@ -283,20 +294,34 @@ class SandboxPool:
         if self.config.on_empty == "fail":
             raise PoolExhaustedError(f"Pool for image '{self.image}' is exhausted")
 
-        # Check global limit before on-demand creation
-        if self._total_limit_callback and self._total_limit_callback():
-            raise PoolExhaustedError(
-                f"Global sandbox limit reached, cannot create on-demand for {self.image}"
-            )
+        # CRITICAL: Pessimistic reservation for on-demand creation
+        # Atomically increment _creating_count and check limit under lock
+        # to prevent TOCTOU race condition
+        async with self._lock:
+            self._creating_count += 1
+            if self._total_limit_callback and self._total_limit_callback():
+                self._creating_count -= 1
+                raise PoolExhaustedError(
+                    f"Global sandbox limit reached, cannot create on-demand for {self.image}"
+                )
 
         # Fall back to cold start
         logger.info(f"Pool empty for {self.image}, creating sandbox on-demand")
-        sandbox = await self._create_sandbox_with_retry(timeout=timeout)
-        latency_ms = (time.time() - start_time) * 1000
-        self._record_acquire(from_pool=False, latency_ms=latency_ms)
-        sandbox._from_pool = False  # Mark for external tracking
-        self._in_use_count += 1  # Track in-use sandbox
-        return sandbox
+        try:
+            sandbox = await self._create_sandbox_no_counter(timeout=timeout)
+            # Atomically transition from creating to in_use
+            async with self._lock:
+                self._creating_count -= 1
+                self._in_use_count += 1
+            latency_ms = (time.time() - start_time) * 1000
+            self._record_acquire(from_pool=False, latency_ms=latency_ms)
+            sandbox._from_pool = False  # Mark for external tracking
+            return sandbox
+        except Exception:
+            # Creation failed - release the reserved slot
+            async with self._lock:
+                self._creating_count -= 1
+            raise
 
     def release(self, sandbox: Sandbox) -> None:
         """Release a sandbox back (decrement in-use count).
@@ -390,6 +415,52 @@ class SandboxPool:
             f"{self.config.create_retries} attempts: {last_error}"
         )
 
+    async def _create_sandbox_no_counter(
+        self, timeout: Optional[float] = None
+    ) -> Sandbox:
+        """Create a sandbox with retry logic, WITHOUT managing _creating_count.
+
+        This method is used when the caller manages _creating_count externally
+        to enable pessimistic reservation (increment before check) and prevent
+        TOCTOU race conditions.
+
+        Args:
+            timeout: Maximum time to wait for sandbox creation
+
+        Returns:
+            A ready Sandbox instance
+
+        Raises:
+            SandboxCreationError: If sandbox creation fails after all retries
+        """
+        last_error: Optional[Exception] = None
+
+        for attempt in range(self.config.create_retries):
+            try:
+                async with self._create_semaphore:
+                    sandbox = await asyncio.to_thread(
+                        Sandbox.create,
+                        image=self.image,
+                        wait_ready=True,
+                        timeout=timeout or 600,
+                        **self._sandbox_defaults,
+                    )
+                    return sandbox
+            except SandboxCreationError as e:
+                last_error = e
+                self._metrics.failed_creates += 1
+                logger.warning(
+                    f"Sandbox creation attempt {attempt + 1}/{self.config.create_retries} "
+                    f"failed for {self.image}: {e}"
+                )
+                if attempt < self.config.create_retries - 1:
+                    await asyncio.sleep(self.config.create_retry_delay)
+
+        raise SandboxCreationError(
+            f"Failed to create sandbox for {self.image} after "
+            f"{self.config.create_retries} attempts: {last_error}"
+        )
+
     async def _destroy_sandbox(self, sandbox: Sandbox) -> None:
         """Destroy a sandbox safely."""
         try:
@@ -416,30 +487,41 @@ class SandboxPool:
             await self._scale_down_one()
             return
 
-        # Check if we need to replenish
-        target = self.config.target_ready if self._is_active else 0
-        current = self.ready_count + self._creating_count
+        # CRITICAL: Hold lock while calculating AND reserving slots to prevent
+        # race condition where multiple replenish cycles spawn duplicate tasks.
+        # Without the lock, the gap between reading _creating_count and spawning
+        # tasks allows the next replenish cycle to see stale counts.
+        async with self._lock:
+            # Check if we need to replenish
+            target = self.config.target_ready if self._is_active else 0
+            current = self.ready_count + self._creating_count
 
-        if current >= target:
-            return
+            if current >= target:
+                return
 
-        # Check global limit
-        if self._total_limit_callback and self._total_limit_callback():
-            logger.debug(f"Global sandbox limit reached, not creating for {self.image}")
-            return
+            # Check global limit
+            if self._total_limit_callback and self._total_limit_callback():
+                logger.debug(f"Global sandbox limit reached, not creating for {self.image}")
+                return
 
-        # Check pool limit
-        if current >= self.config.max_ready:
-            return
+            # Check pool limit
+            if current >= self.config.max_ready:
+                return
 
-        # Calculate how many sandboxes to create
-        needed = target - current
-        available = self.config.max_ready - current
-        to_create = min(needed, available)
+            # Calculate how many sandboxes to create
+            needed = target - current
+            available = self.config.max_ready - current
+            to_create = min(needed, available)
 
-        # Start ALL needed creations at once (semaphore limits actual concurrency)
+            # Reserve slots BEFORE spawning tasks (pessimistic reservation)
+            # This ensures subsequent replenish cycles see accurate counts
+            self._creating_count += to_create
+
+        # Now spawn tasks outside the lock (they'll decrement when done)
         for _ in range(to_create):
-            asyncio.create_task(self._create_and_add_to_pool())
+            task = asyncio.create_task(self._create_and_add_to_pool_reserved())
+            self._creation_tasks.add(task)
+            task.add_done_callback(self._creation_tasks.discard)
             self._metrics.scale_up_events += 1
 
     async def _should_scale_down(self) -> bool:
@@ -485,15 +567,74 @@ class SandboxPool:
 
     async def _create_and_add_to_pool(self) -> None:
         """Create a sandbox and add it to the pool."""
+        # CRITICAL: Pessimistic reservation - increment BEFORE checking limit
+        # This prevents TOCTOU race condition where multiple tasks pass the
+        # limit check before any of them increment _creating_count.
+        # By incrementing first (under lock), each task sees its own increment
+        # reflected in the count when checking the limit.
+        async with self._lock:
+            self._creating_count += 1
+            if self._total_limit_callback and self._total_limit_callback():
+                self._creating_count -= 1
+                logger.debug(f"Global limit reached, skipping pool creation for {self.image}")
+                return
+
         try:
-            sandbox = await self._create_sandbox_with_retry()
-            if not self._shutdown:
+            sandbox = await self._create_sandbox_no_counter()
+            if self._shutdown:
+                # Shutdown triggered while we were creating - destroy immediately
+                # to avoid orphaned sandboxes that exist on DO but aren't tracked
+                logger.debug(f"Shutdown in progress, destroying just-created sandbox for {self.image}")
+                await self._destroy_sandbox(sandbox)
+            else:
                 await self._ready_queue.put(_PooledSandbox(sandbox=sandbox))
                 logger.debug(
                     f"Added sandbox to pool for {self.image}, now {self.ready_count} ready"
                 )
+        except asyncio.CancelledError:
+            # Task was cancelled during shutdown - this is expected
+            logger.debug(f"Sandbox creation cancelled for {self.image} (shutdown)")
+            raise  # Re-raise so gather with return_exceptions=True captures it
         except Exception as e:
             logger.error(f"Failed to create sandbox for pool {self.image}: {e}")
+        finally:
+            async with self._lock:
+                self._creating_count -= 1
+
+    async def _create_and_add_to_pool_reserved(self) -> None:
+        """Create a sandbox and add it to the pool (slot already reserved).
+
+        This method is used when _creating_count was already incremented by
+        the caller (e.g., _replenish_once with pessimistic reservation).
+        It only decrements on completion, never increments.
+        """
+        # Check global limit first (slot reserved, but global might have filled)
+        async with self._lock:
+            if self._total_limit_callback and self._total_limit_callback():
+                self._creating_count -= 1  # Release reserved slot
+                logger.debug(f"Global limit reached, releasing reserved slot for {self.image}")
+                return
+
+        try:
+            sandbox = await self._create_sandbox_no_counter()
+            if self._shutdown:
+                # Shutdown triggered while we were creating - destroy immediately
+                logger.debug(f"Shutdown in progress, destroying just-created sandbox for {self.image}")
+                await self._destroy_sandbox(sandbox)
+            else:
+                await self._ready_queue.put(_PooledSandbox(sandbox=sandbox))
+                logger.debug(
+                    f"Added sandbox to pool for {self.image}, now {self.ready_count} ready"
+                )
+        except asyncio.CancelledError:
+            # Task was cancelled during shutdown - this is expected
+            logger.debug(f"Sandbox creation cancelled for {self.image} (shutdown)")
+            raise  # Re-raise so gather with return_exceptions=True captures it
+        except Exception as e:
+            logger.error(f"Failed to create sandbox for pool {self.image}: {e}")
+        finally:
+            async with self._lock:
+                self._creating_count -= 1
 
     async def _health_check_loop(self) -> None:
         """Background task to check health of pooled sandboxes."""

--- a/tests/rigorous_pool_test/README.md
+++ b/tests/rigorous_pool_test/README.md
@@ -1,0 +1,192 @@
+# Rigorous Pool Test - Command Reference
+
+A comprehensive stress test for the `do-app-sandbox` Python SDK.
+
+## Quick Start
+
+```bash
+# Navigate to the SDK directory
+cd /Users/bgupta/Documents/Builder/sandbox-stress/do-app-sandbox-main
+
+# Run smoke test (10 minutes, 5 sandboxes)
+uv run python -m tests.rigorous_pool_test.run_25cap_4hr --smoke
+```
+
+---
+
+## Test Commands
+
+### 1. Smoke Test (Recommended First)
+Quick validation of environment, credentials, and basic functionality.
+
+```bash
+uv run python -m tests.rigorous_pool_test.run_25cap_4hr --smoke
+```
+
+**Parameters:** 10 minutes, 5 max sandboxes, 4 workers, target_ready=3
+
+---
+
+### 2. Main 4-Hour Run
+Full stress test as specified in Task.md requirements.
+
+```bash
+uv run python -m tests.rigorous_pool_test.run_25cap_4hr \
+    --duration-seconds 14400 \
+    --max-total 25 \
+    --concurrency 12 \
+    --python-target-ready 12 \
+    --region syd1
+```
+
+**Parameters:** 4 hours, 25 max sandboxes, 12 workers, target_ready=12
+
+---
+
+### 3. Pool Starvation Test
+Forces cold starts by keeping pool target low with high demand.
+
+```bash
+uv run python -m tests.rigorous_pool_test.run_25cap_4hr \
+    --duration-seconds 1800 \
+    --max-total 25 \
+    --concurrency 16 \
+    --python-target-ready 2
+```
+
+**Parameters:** 30 minutes, 25 max sandboxes, 16 workers (high demand), target_ready=2 (low pool)
+
+---
+
+### 4. Custom Configuration
+Full list of available options:
+
+```bash
+uv run python -m tests.rigorous_pool_test.run_25cap_4hr \
+    --duration-seconds 3600 \      # Test duration (seconds)
+    --max-total 15 \               # Max sandboxes (HARD LIMIT)
+    --region syd1 \                # Sandbox region
+    --instance-size basic-xxs \    # Instance size
+    --concurrency 8 \              # Number of virtual users
+    --python-target-ready 6 \      # Pool target ready count
+    --python-max-ready 10 \        # Pool max ready count
+    --watchdog-interval 10 \       # doctl polling interval (seconds)
+    --watchdog-grace 2 \           # Grace period for brief overage
+    --enable-emergency-cleanup \   # Auto-delete excess sandboxes
+    --debug                        # Enable debug logging
+```
+
+---
+
+### 5. Without Watchdog
+Disable external doctl-based monitoring (not recommended):
+
+```bash
+uv run python -m tests.rigorous_pool_test.run_25cap_4hr \
+    --smoke \
+    --disable-watchdog
+```
+
+---
+
+### 6. With Emergency Cleanup
+Enable automatic deletion of excess sandboxes on watchdog violation:
+
+```bash
+uv run python -m tests.rigorous_pool_test.run_25cap_4hr \
+    --smoke \
+    --enable-emergency-cleanup
+```
+
+---
+
+### 7. Disable Network Commands
+Skip commands that require network access (DNS lookups):
+
+```bash
+uv run python -m tests.rigorous_pool_test.run_25cap_4hr \
+    --smoke \
+    --disable-network-commands
+```
+
+---
+
+## CLI Options Reference
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--smoke` | false | Run smoke test preset (10min, 5 sandboxes) |
+| `--duration-seconds` | 14400 | Test duration in seconds |
+| `--max-total` | 25 | Maximum sandboxes (HARD LIMIT) |
+| `--region` | syd1 | Sandbox region |
+| `--instance-size` | basic-xxs | Sandbox instance size |
+| `--concurrency` | 12 | Number of virtual users (workers) |
+| `--python-target-ready` | 12 | Python pool target ready count |
+| `--python-max-ready` | 15 | Python pool max ready count |
+| `--node-target-ready` | 0 | Node pool target ready (0 = disabled) |
+| `--report-dir` | auto | Report output directory |
+| `--watchdog-interval` | 10.0 | doctl polling interval (seconds) |
+| `--watchdog-grace` | 2 | Grace period for brief overage |
+| `--disable-watchdog` | false | Disable external monitoring |
+| `--enable-emergency-cleanup` | false | Auto-delete excess sandboxes |
+| `--disable-network-commands` | false | Skip network-dependent commands |
+| `--debug` | false | Enable debug logging |
+
+---
+
+## Output Reports
+
+Reports are written to `tests/artifacts/rigorous_pool_test/<timestamp>/`:
+
+| File | Description |
+|------|-------------|
+| `summary.json` | Pass/fail status and key metrics |
+| `summary.txt` | Human-readable summary |
+| `sessions.csv` | Per-session data |
+| `commands.csv.gz` | Per-command data (compressed) |
+| `pool_metrics.json` | Raw pool metrics from SDK |
+| `test.log` | Full test log |
+
+---
+
+## Checking Results
+
+```bash
+# View summary
+cat tests/artifacts/rigorous_pool_test/*/summary.txt
+
+# Check if test passed
+jq '.pass' tests/artifacts/rigorous_pool_test/*/summary.json
+
+# View watchdog metrics
+jq '.watchdog' tests/artifacts/rigorous_pool_test/*/summary.json
+
+# Count command failures
+jq '.total_command_failures' tests/artifacts/rigorous_pool_test/*/summary.json
+```
+
+---
+
+## Manual Cleanup
+
+If tests are interrupted, manually check for orphaned sandboxes:
+
+```bash
+# List all sandbox apps
+doctl apps list | grep -i sandbox
+
+# Delete specific app
+doctl apps delete <app-id> --force
+
+# Delete all sandbox apps (USE WITH CAUTION)
+doctl apps list --format ID,Spec.Name --no-header | grep -i sandbox | awk '{print $1}' | xargs -I {} doctl apps delete {} --force
+```
+
+---
+
+## Test Objectives (from Task.md)
+
+- **Command Correctness:** 0% failure rate for `sandbox.exec()` calls
+- **Pool Effectiveness:** Track pool hit rate vs cold starts
+- **Capacity Enforcement:** Never exceed 25 sandboxes
+- **Lifecycle Robustness:** Clean create/delete cycles over 4 hours

--- a/tests/rigorous_pool_test/__init__.py
+++ b/tests/rigorous_pool_test/__init__.py
@@ -1,0 +1,14 @@
+"""
+Rigorous Pool Test for do-app-sandbox SDK.
+
+A comprehensive 4-hour stress test that validates:
+- Command correctness (0 failure tolerance)
+- Pool effectiveness (pool hits vs cold starts)
+- Capacity enforcement (never exceed 25 sandboxes)
+- Lifecycle robustness
+
+Run with:
+    uv run python -m tests.rigorous_pool_test.run_25cap_4hr --help
+"""
+
+__version__ = "1.0.0"

--- a/tests/rigorous_pool_test/commands.py
+++ b/tests/rigorous_pool_test/commands.py
@@ -1,0 +1,167 @@
+"""
+Command suite generation for rigorous pool testing.
+
+Generates deterministic command bundles with variation per iteration.
+"""
+
+from typing import List
+
+
+def build_python_command_bundle(iteration: int, enable_network: bool = True) -> List[str]:
+    """
+    Build a bundle of Python sandbox commands for one iteration.
+
+    Args:
+        iteration: Current iteration number (used for unique file names)
+        enable_network: Whether to include network-dependent commands
+
+    Returns:
+        List of command strings to execute
+    """
+    commands = [
+        # 1. Version check
+        "python --version",
+        # 2. Basic print
+        'python -c "print(\'hello\')"',
+        # 3. Working directory
+        'python -c "import os; print(os.getcwd())"',
+        # 4. Platform info
+        'python -c "import platform; print(platform.platform())"',
+        # 5. Brief sleep (test timing)
+        'python -c "import time; time.sleep(0.1); print(\'slept\')"',
+        # 6. CPU-bound work (hashing)
+        'python -c "import hashlib; print(hashlib.sha256(b\'x\'*100000).hexdigest())"',
+        # 7. JSON output with iteration
+        f'python -c "import json; print(json.dumps({{\'i\': {iteration}}}))"',
+        # 8. File write
+        f'bash -lc "echo test_{iteration} > /tmp/t_{iteration}.txt"',
+        # 9. File read/size
+        f'bash -lc "wc -c /tmp/t_{iteration}.txt"',
+        # 10. Directory listing
+        'bash -lc "ls -la /tmp | head"',
+        # 11. System info
+        'bash -lc "uname -a"',
+    ]
+
+    # 12. Network command (optional)
+    if enable_network:
+        commands.append(
+            'python -c "import socket; print(socket.gethostbyname(\'example.com\'))"'
+        )
+
+    return commands
+
+
+def build_node_command_bundle(iteration: int, enable_network: bool = True) -> List[str]:
+    """
+    Build a bundle of Node sandbox commands for one iteration.
+
+    Args:
+        iteration: Current iteration number
+        enable_network: Whether to include network-dependent commands
+
+    Returns:
+        List of command strings to execute
+    """
+    commands = [
+        # 1. Version check
+        "node --version",
+        # 2. Basic console log
+        'node -e "console.log(\'hi\')"',
+        # 3. CPU-bound work (hashing)
+        'node -e "const crypto=require(\'crypto\'); console.log(crypto.createHash(\'sha256\').update(\'x\'.repeat(1e5)).digest(\'hex\'))"',
+        # 4. JSON output with iteration
+        f'node -e "console.log(JSON.stringify({{i: {iteration}}}))"',
+        # 5. File operations via bash
+        f'bash -lc "echo node_test_{iteration} > /tmp/node_{iteration}.txt"',
+        f'bash -lc "cat /tmp/node_{iteration}.txt"',
+        # 6. System info
+        'bash -lc "uname -a"',
+    ]
+
+    return commands
+
+
+def build_process_management_bundle(iteration: int) -> List[tuple[str, str]]:
+    """
+    Build process management commands (spawn + kill).
+
+    Returns list of (command, description) tuples.
+    Only run every ~25 iterations.
+    """
+    if iteration % 25 != 0:
+        return []
+
+    return [
+        ('bash -lc "sleep 30 & echo $!"', "spawn_background_process"),
+        # Note: The PID from the above command needs to be captured
+        # and used to kill the process. This is handled in session.py
+    ]
+
+
+def build_filesystem_test_bundle(iteration: int) -> List[tuple[str, str]]:
+    """
+    Build filesystem API test commands (via SDK, not exec).
+
+    Returns list of (operation, path, content) tuples for SDK filesystem calls.
+    Only run every ~10 iterations.
+    """
+    if iteration % 10 != 0:
+        return []
+
+    return [
+        ("write", f"/tmp/sdk_test_{iteration}.txt", f"sdk content {iteration}"),
+        ("read", f"/tmp/sdk_test_{iteration}.txt", None),
+        ("exists", f"/tmp/sdk_test_{iteration}.txt", None),
+        ("list", "/tmp", None),
+    ]
+
+
+def get_command_budget(hold_time_seconds: int) -> int:
+    """
+    Calculate command budget based on hold time.
+
+    Target: ~25 commands per 5 minutes (5 commands/min).
+
+    Args:
+        hold_time_seconds: Planned hold time in seconds
+
+    Returns:
+        Number of commands to execute during the session
+    """
+    hold_minutes = hold_time_seconds / 60
+    return min(500, max(10, int(hold_minutes * 5)))
+
+
+def build_command_list(
+    image: str,
+    total_commands: int,
+    enable_network: bool = True,
+) -> List[str]:
+    """
+    Build a list of commands for a session.
+
+    Args:
+        image: Sandbox image ("python" or "node")
+        total_commands: Total number of commands to generate
+        enable_network: Whether to include network-dependent commands
+
+    Returns:
+        List of command strings to execute
+    """
+    commands = []
+    iteration = 0
+
+    while len(commands) < total_commands:
+        if image == "python":
+            bundle = build_python_command_bundle(iteration, enable_network)
+        elif image == "node":
+            bundle = build_node_command_bundle(iteration, enable_network)
+        else:
+            raise ValueError(f"Unknown image: {image}")
+
+        commands.extend(bundle)
+        iteration += 1
+
+    # Trim to exact count
+    return commands[:total_commands]

--- a/tests/rigorous_pool_test/config.py
+++ b/tests/rigorous_pool_test/config.py
@@ -1,0 +1,127 @@
+"""
+Configuration dataclasses for the rigorous pool test.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class TestConfig:
+    """Main test configuration."""
+
+    # Duration
+    duration_seconds: int = 14400  # 4 hours
+
+    # Sandbox limits
+    max_total_sandboxes: int = 25  # Hard cap - NEVER exceed
+    max_concurrent_creates: int = 10
+
+    # Region and sizing
+    region: str = "syd1"
+    instance_size: str = "basic-xxs"
+
+    # Concurrency
+    concurrency: int = 12  # Number of virtual users
+
+    # Pool configuration
+    python_target_ready: int = 12
+    python_max_ready: int = 15
+    node_target_ready: int = 0
+    node_max_ready: int = 0
+
+    # Command execution
+    enable_network_commands: bool = True
+
+    # Hold time configuration (seconds)
+    # For smoke tests, use shorter hold times (60-180s)
+    # For main tests, use longer hold times (300-3600s)
+    hold_time_min: int = 300  # 5 minutes default
+    hold_time_max: int = 600  # 10 minutes default
+
+    # Reporting
+    report_dir: Optional[str] = None
+
+    # Watchdog configuration
+    watchdog_enabled: bool = True
+    watchdog_interval: float = 10.0  # seconds
+    watchdog_grace_period: int = 15  # Allow surge for terminating apps (Concurrency 12 + buffer)
+    watchdog_sandbox_pattern: str = "sandbox"
+
+    def __post_init__(self):
+        """Generate report directory if not specified."""
+        if self.report_dir is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            self.report_dir = f"tests/artifacts/rigorous_pool_test/{timestamp}"
+
+
+@dataclass
+class WatchdogConfig:
+    """Configuration for the external sandbox watchdog."""
+
+    max_sandboxes: int = 25
+    poll_interval: float = 10.0  # seconds
+    sandbox_name_pattern: str = "sandbox"
+    grace_period: int = 2  # Allow brief overage for in-flight creates
+
+
+@dataclass
+class HoldTimeConfig:
+    """Configuration for hold time distribution."""
+
+    # Distribution: 40% short, 40% medium, 20% long
+    short_min: int = 300  # 5 minutes
+    short_max: int = 600  # 10 minutes
+    short_weight: float = 0.4
+
+    medium_min: int = 600  # 10 minutes
+    medium_max: int = 1200  # 20 minutes
+    medium_weight: float = 0.4
+
+    long_min: int = 1200  # 20 minutes
+    long_max: int = 3600  # 60 minutes
+    long_weight: float = 0.2
+
+
+@dataclass
+class RetryConfig:
+    """Configuration for retry policies."""
+
+    # Command execution retries
+    exec_retries: int = 2
+    exec_retry_delay: float = 1.5  # seconds
+
+    # Delete retries
+    delete_retries: int = 3
+    delete_retry_delay: float = 2.0  # seconds
+
+
+# Preset configurations
+SMOKE_CONFIG = TestConfig(
+    duration_seconds=600,  # 10 minutes
+    max_total_sandboxes=5,
+    concurrency=2,  # Reduced to 2 so (2 workers + 3 pool) <= 5 max
+    python_target_ready=3,
+    python_max_ready=5,
+    hold_time_min=60,   # 1 minute - SHORT for smoke test
+    hold_time_max=120,  # 2 minutes - SHORT for smoke test
+)
+
+MAIN_4HR_CONFIG = TestConfig(
+    duration_seconds=14400,  # 4 hours
+    max_total_sandboxes=25,
+    concurrency=12,
+    python_target_ready=12,
+    python_max_ready=15,
+    region="syd1",
+)
+
+STARVATION_CONFIG = TestConfig(
+    duration_seconds=1800,  # 30 minutes
+    max_total_sandboxes=25,
+    concurrency=16,  # More demand than pool can handle
+    python_target_ready=2,  # Force cold starts
+    python_max_ready=5,
+)

--- a/tests/rigorous_pool_test/metrics.py
+++ b/tests/rigorous_pool_test/metrics.py
@@ -1,0 +1,321 @@
+"""
+Metrics collection and aggregation for rigorous pool testing.
+"""
+
+import asyncio
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from .session import SessionResult
+from .utils import percentile
+
+logger = logging.getLogger("rigorous_pool_test")
+
+
+@dataclass
+class PoolSnapshot:
+    """Snapshot of pool state at a point in time."""
+
+    timestamp: datetime
+    image: str
+    ready: int
+    creating: int
+    in_use: int
+    total: int
+
+
+@dataclass
+class WatchdogMetrics:
+    """Metrics from the external watchdog."""
+
+    enabled: bool = True
+    violation_detected: bool = False
+    max_observed_via_doctl: int = 0
+    total_checks: int = 0
+    emergency_deletions: int = 0
+
+
+@dataclass
+class TestSummary:
+    """Final summary of the test run."""
+
+    test_name: str = "rigorous_pool_test"
+    passed: bool = True
+    duration_seconds: float = 0
+    total_sessions: int = 0
+    total_commands: int = 0
+    total_command_failures: int = 0
+
+    # Pool metrics
+    pool_hit_rate_overall: float = 0.0
+    pool_hit_rate_by_image: Dict[str, float] = field(default_factory=dict)
+    cold_start_count: int = 0
+    failed_creates: int = 0
+
+    # Latency percentiles
+    acquire_latency_ms_p50: float = 0.0
+    acquire_latency_ms_p90: float = 0.0
+    acquire_latency_ms_p99: float = 0.0
+    acquire_latency_pool_p50: float = 0.0
+    acquire_latency_pool_p90: float = 0.0
+    acquire_latency_cold_p50: float = 0.0
+    acquire_latency_cold_p90: float = 0.0
+
+    # Capacity
+    max_total_sandboxes_observed: int = 0
+    capacity_violations: int = 0
+    leaked_sandboxes: int = 0
+
+    # Watchdog
+    watchdog: WatchdogMetrics = field(default_factory=WatchdogMetrics)
+
+    # Timing
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+
+
+class MetricsCollector:
+    """Thread-safe metrics collection and aggregation."""
+
+    def __init__(self, max_total: int = 25):
+        self.max_total = max_total
+        self._lock = threading.Lock()
+        self._sessions: List[SessionResult] = []
+        self._pool_snapshots: List[PoolSnapshot] = []
+        self._max_observed_total: int = 0
+        self._capacity_violations: int = 0
+        self._failed_creates: int = 0
+        self._start_time: Optional[datetime] = None
+        self._end_time: Optional[datetime] = None
+
+    def start(self):
+        """Mark test start time."""
+        self._start_time = datetime.now()
+
+    def stop(self):
+        """Mark test end time."""
+        self._end_time = datetime.now()
+
+    def add_session(self, result: SessionResult):
+        """Add a completed session result."""
+        with self._lock:
+            self._sessions.append(result)
+
+    def record_pool_snapshot(
+        self,
+        pool_metrics: Dict[str, Any],
+        timestamp: Optional[datetime] = None,
+    ):
+        """
+        Record a snapshot of pool state.
+
+        Args:
+            pool_metrics: Output from manager.metrics()
+            timestamp: Optional timestamp (uses now if not provided)
+        """
+        if timestamp is None:
+            timestamp = datetime.now()
+
+        with self._lock:
+            total_all = 0
+
+            for image, metrics in pool_metrics.items():
+                ready = getattr(metrics, "ready", 0)
+                creating = getattr(metrics, "creating", 0)
+                in_use = getattr(metrics, "in_use", 0)
+                total = ready + creating + in_use
+                total_all += total
+
+                snapshot = PoolSnapshot(
+                    timestamp=timestamp,
+                    image=image,
+                    ready=ready,
+                    creating=creating,
+                    in_use=in_use,
+                    total=total,
+                )
+                self._pool_snapshots.append(snapshot)
+
+                # Track failed creates
+                failed = getattr(metrics, "failed_creates", 0)
+                if failed > self._failed_creates:
+                    self._failed_creates = failed
+
+            # Track max observed
+            if total_all > self._max_observed_total:
+                self._max_observed_total = total_all
+
+            # Check capacity violation
+            if total_all > self.max_total:
+                self._capacity_violations += 1
+                logger.critical(
+                    f"CAPACITY VIOLATION: {total_all} sandboxes (limit: {self.max_total})"
+                )
+
+    async def sample_pool_metrics(
+        self,
+        manager: Any,
+        interval: float = 5.0,
+        stop_event: asyncio.Event = None,
+    ):
+        """
+        Periodically sample manager.metrics() and track state.
+
+        Args:
+            manager: SandboxManager instance
+            interval: Sampling interval in seconds
+            stop_event: Event to signal termination
+        """
+        logger.info(f"Starting pool metrics sampling (interval={interval}s)")
+        sample_count = 0
+
+        while stop_event is None or not stop_event.is_set():
+            try:
+                metrics = manager.metrics()
+                self.record_pool_snapshot(metrics)
+                sample_count += 1
+
+                # Log current state
+                total = sum(
+                    getattr(m, "ready", 0)
+                    + getattr(m, "creating", 0)
+                    + getattr(m, "in_use", 0)
+                    for m in metrics.values()
+                )
+                logger.debug(f"Pool snapshot: total={total}, max_observed={self._max_observed_total}")
+
+                # Log overall progress every 60 seconds (12 samples at 5s interval)
+                if sample_count % 12 == 0:
+                    with self._lock:
+                        total_sessions = len(self._sessions)
+                        total_commands = sum(s.total_commands_executed for s in self._sessions)
+                        total_failures = sum(s.command_failures_count for s in self._sessions)
+
+                    elapsed = (datetime.now() - self._start_time).total_seconds() if self._start_time else 0
+                    logger.info(
+                        f"PROGRESS: {elapsed/60:.1f}m elapsed | "
+                        f"sessions={total_sessions} | cmds={total_commands} | "
+                        f"failures={total_failures} | sandboxes={total} (max={self._max_observed_total})"
+                    )
+
+            except Exception as e:
+                logger.error(f"Error sampling pool metrics: {e}")
+
+            # Wait for next interval
+            if stop_event:
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=interval)
+                    break  # Stop event was set
+                except asyncio.TimeoutError:
+                    pass  # Continue sampling
+            else:
+                await asyncio.sleep(interval)
+
+        logger.info("Pool metrics sampling stopped")
+
+    def get_summary(
+        self,
+        watchdog_metrics: Optional[WatchdogMetrics] = None,
+    ) -> TestSummary:
+        """
+        Compute final summary statistics.
+
+        Args:
+            watchdog_metrics: Metrics from external watchdog
+
+        Returns:
+            Complete test summary
+        """
+        with self._lock:
+            summary = TestSummary()
+            summary.start_time = self._start_time
+            summary.end_time = self._end_time
+
+            if self._start_time and self._end_time:
+                summary.duration_seconds = (
+                    self._end_time - self._start_time
+                ).total_seconds()
+
+            # Session counts
+            summary.total_sessions = len(self._sessions)
+            summary.total_commands = sum(s.total_commands_executed for s in self._sessions)
+            summary.total_command_failures = sum(
+                s.command_failures_count for s in self._sessions
+            )
+
+            # Pool hit rate
+            pool_hits = sum(1 for s in self._sessions if s.from_pool)
+            if summary.total_sessions > 0:
+                summary.pool_hit_rate_overall = pool_hits / summary.total_sessions
+            summary.cold_start_count = summary.total_sessions - pool_hits
+
+            # Pool hit rate by image
+            for image in set(s.image for s in self._sessions):
+                image_sessions = [s for s in self._sessions if s.image == image]
+                image_pool_hits = sum(1 for s in image_sessions if s.from_pool)
+                if image_sessions:
+                    summary.pool_hit_rate_by_image[image] = (
+                        image_pool_hits / len(image_sessions)
+                    )
+
+            # Latency percentiles
+            all_latencies = [s.acquire_latency_ms for s in self._sessions]
+            pool_latencies = [
+                s.acquire_latency_ms for s in self._sessions if s.from_pool
+            ]
+            cold_latencies = [
+                s.acquire_latency_ms for s in self._sessions if not s.from_pool
+            ]
+
+            if all_latencies:
+                summary.acquire_latency_ms_p50 = percentile(all_latencies, 50)
+                summary.acquire_latency_ms_p90 = percentile(all_latencies, 90)
+                summary.acquire_latency_ms_p99 = percentile(all_latencies, 99)
+
+            if pool_latencies:
+                summary.acquire_latency_pool_p50 = percentile(pool_latencies, 50)
+                summary.acquire_latency_pool_p90 = percentile(pool_latencies, 90)
+
+            if cold_latencies:
+                summary.acquire_latency_cold_p50 = percentile(cold_latencies, 50)
+                summary.acquire_latency_cold_p90 = percentile(cold_latencies, 90)
+
+            # Capacity metrics
+            summary.max_total_sandboxes_observed = self._max_observed_total
+            summary.capacity_violations = self._capacity_violations
+            summary.failed_creates = self._failed_creates
+
+            # Watchdog metrics
+            if watchdog_metrics:
+                summary.watchdog = watchdog_metrics
+
+            # Determine pass/fail
+            summary.passed = (
+                summary.total_command_failures == 0
+                and summary.capacity_violations == 0
+                and summary.max_total_sandboxes_observed <= self.max_total
+                and not (watchdog_metrics and watchdog_metrics.violation_detected)
+            )
+
+            return summary
+
+    @property
+    def sessions(self) -> List[SessionResult]:
+        """Get all session results."""
+        with self._lock:
+            return list(self._sessions)
+
+    @property
+    def max_observed_total(self) -> int:
+        """Get maximum observed total sandbox count."""
+        with self._lock:
+            return self._max_observed_total
+
+    @property
+    def capacity_violations(self) -> int:
+        """Get number of capacity violations detected."""
+        with self._lock:
+            return self._capacity_violations

--- a/tests/rigorous_pool_test/reporter.py
+++ b/tests/rigorous_pool_test/reporter.py
@@ -1,0 +1,293 @@
+"""
+Report generation for rigorous pool testing.
+
+Generates:
+- summary.json: Overall pass/fail and key stats
+- summary.txt: Human-readable summary
+- sessions.csv: Per-session data
+- commands.csv.gz: Per-command data (compressed)
+- pool_metrics.json: Raw pool metrics
+"""
+
+import csv
+import gzip
+import json
+import logging
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .metrics import TestSummary
+from .session import SessionResult
+from .utils import format_duration
+
+logger = logging.getLogger("rigorous_pool_test")
+
+
+class Reporter:
+    """Handles all report generation."""
+
+    def __init__(self, report_dir: str):
+        self.report_dir = Path(report_dir)
+        self.report_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Report directory: {self.report_dir}")
+
+    def write_summary_json(self, summary: TestSummary):
+        """Write summary.json with pass/fail and key stats."""
+        path = self.report_dir / "summary.json"
+
+        data = {
+            "test_name": summary.test_name,
+            "pass": summary.passed,
+            "duration_seconds": summary.duration_seconds,
+            "total_sessions": summary.total_sessions,
+            "total_commands": summary.total_commands,
+            "total_command_failures": summary.total_command_failures,
+            "pool_hit_rate_overall": round(summary.pool_hit_rate_overall, 4),
+            "pool_hit_rate_by_image": {
+                k: round(v, 4) for k, v in summary.pool_hit_rate_by_image.items()
+            },
+            "cold_start_count": summary.cold_start_count,
+            "acquire_latency_ms": {
+                "p50": round(summary.acquire_latency_ms_p50, 1),
+                "p90": round(summary.acquire_latency_ms_p90, 1),
+                "p99": round(summary.acquire_latency_ms_p99, 1),
+            },
+            "acquire_latency_pool_ms": {
+                "p50": round(summary.acquire_latency_pool_p50, 1),
+                "p90": round(summary.acquire_latency_pool_p90, 1),
+            },
+            "acquire_latency_cold_ms": {
+                "p50": round(summary.acquire_latency_cold_p50, 1),
+                "p90": round(summary.acquire_latency_cold_p90, 1),
+            },
+            "max_total_sandboxes_observed": summary.max_total_sandboxes_observed,
+            "capacity_violations": summary.capacity_violations,
+            "failed_creates": summary.failed_creates,
+            "leaked_sandboxes": summary.leaked_sandboxes,
+            "watchdog": {
+                "enabled": summary.watchdog.enabled,
+                "violation_detected": summary.watchdog.violation_detected,
+                "max_observed_via_doctl": summary.watchdog.max_observed_via_doctl,
+                "total_checks": summary.watchdog.total_checks,
+                "emergency_deletions": summary.watchdog.emergency_deletions,
+            },
+            "start_time": summary.start_time.isoformat() if summary.start_time else None,
+            "end_time": summary.end_time.isoformat() if summary.end_time else None,
+        }
+
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
+        logger.info(f"Wrote {path}")
+
+    def write_summary_txt(self, summary: TestSummary):
+        """Write human-readable summary.txt."""
+        path = self.report_dir / "summary.txt"
+
+        lines = [
+            "=" * 60,
+            "RIGOROUS POOL TEST SUMMARY",
+            "=" * 60,
+            "",
+            f"Result: {'PASS' if summary.passed else 'FAIL'}",
+            f"Duration: {format_duration(summary.duration_seconds)}",
+            "",
+            "--- Sessions ---",
+            f"Total sessions: {summary.total_sessions}",
+            f"Pool hits: {summary.total_sessions - summary.cold_start_count} ({summary.pool_hit_rate_overall*100:.1f}%)",
+            f"Cold starts: {summary.cold_start_count}",
+            "",
+            "--- Commands ---",
+            f"Total commands: {summary.total_commands}",
+            f"Command failures: {summary.total_command_failures}",
+            f"Failure rate: {summary.total_command_failures/max(summary.total_commands,1)*100:.2f}%",
+            "",
+            "--- Acquire Latency ---",
+            f"Overall p50/p90/p99: {summary.acquire_latency_ms_p50:.0f}ms / {summary.acquire_latency_ms_p90:.0f}ms / {summary.acquire_latency_ms_p99:.0f}ms",
+            f"Pool hits p50/p90: {summary.acquire_latency_pool_p50:.0f}ms / {summary.acquire_latency_pool_p90:.0f}ms",
+            f"Cold starts p50/p90: {summary.acquire_latency_cold_p50:.0f}ms / {summary.acquire_latency_cold_p90:.0f}ms",
+            "",
+            "--- Capacity ---",
+            f"Max sandboxes observed: {summary.max_total_sandboxes_observed}",
+            f"Capacity violations: {summary.capacity_violations}",
+            f"Failed creates: {summary.failed_creates}",
+            "",
+            "--- Watchdog ---",
+            f"Enabled: {summary.watchdog.enabled}",
+            f"Violation detected: {summary.watchdog.violation_detected}",
+            f"Max observed via doctl: {summary.watchdog.max_observed_via_doctl}",
+            f"Total checks: {summary.watchdog.total_checks}",
+            "",
+            "=" * 60,
+        ]
+
+        with open(path, "w") as f:
+            f.write("\n".join(lines))
+
+        logger.info(f"Wrote {path}")
+
+    def write_sessions_csv(self, sessions: List[SessionResult]):
+        """Write sessions.csv with per-session data."""
+        path = self.report_dir / "sessions.csv"
+
+        fieldnames = [
+            "session_id",
+            "image",
+            "from_pool",
+            "acquire_latency_ms",
+            "sandbox_id",
+            "app_id",
+            "region",
+            "hold_seconds_planned",
+            "hold_seconds_actual",
+            "total_commands_planned",
+            "total_commands_executed",
+            "command_failures_count",
+            "delete_latency_ms",
+            "error",
+            "start_time",
+            "end_time",
+        ]
+
+        with open(path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+
+            for session in sessions:
+                writer.writerow({
+                    "session_id": session.session_id,
+                    "image": session.image,
+                    "from_pool": session.from_pool,
+                    "acquire_latency_ms": round(session.acquire_latency_ms, 1),
+                    "sandbox_id": session.sandbox_id,
+                    "app_id": session.app_id,
+                    "region": session.region,
+                    "hold_seconds_planned": session.hold_seconds_planned,
+                    "hold_seconds_actual": round(session.hold_seconds_actual, 1),
+                    "total_commands_planned": session.total_commands_planned,
+                    "total_commands_executed": session.total_commands_executed,
+                    "command_failures_count": session.command_failures_count,
+                    "delete_latency_ms": round(session.delete_latency_ms, 1),
+                    "error": session.error or "",
+                    "start_time": session.start_time.isoformat(),
+                    "end_time": session.end_time.isoformat() if session.end_time else "",
+                })
+
+        logger.info(f"Wrote {path} ({len(sessions)} sessions)")
+
+    def write_commands_csv(
+        self,
+        sessions: List[SessionResult],
+        compress: bool = True,
+    ):
+        """
+        Write commands.csv with per-command data.
+
+        Args:
+            sessions: List of session results
+            compress: Whether to gzip the output
+        """
+        filename = "commands.csv.gz" if compress else "commands.csv"
+        path = self.report_dir / filename
+
+        fieldnames = [
+            "session_id",
+            "command_index",
+            "command",
+            "exit_code",
+            "duration_ms",
+            "stdout_snippet",
+            "stderr_snippet",
+            "retry_count",
+            "timestamp",
+        ]
+
+        total_commands = 0
+        open_func = gzip.open if compress else open
+        mode = "wt" if compress else "w"
+
+        with open_func(path, mode, newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+
+            for session in sessions:
+                for cmd in session.commands:
+                    writer.writerow({
+                        "session_id": cmd.session_id,
+                        "command_index": cmd.command_index,
+                        "command": cmd.command,
+                        "exit_code": cmd.exit_code,
+                        "duration_ms": round(cmd.duration_ms, 1),
+                        "stdout_snippet": cmd.stdout_snippet,
+                        "stderr_snippet": cmd.stderr_snippet,
+                        "retry_count": cmd.retry_count,
+                        "timestamp": cmd.timestamp.isoformat(),
+                    })
+                    total_commands += 1
+
+        logger.info(f"Wrote {path} ({total_commands} commands)")
+
+    def write_pool_metrics_json(
+        self,
+        raw_metrics: Dict[str, Any],
+        max_observed: int,
+    ):
+        """Write pool_metrics.json with raw manager metrics."""
+        path = self.report_dir / "pool_metrics.json"
+
+        # Convert PoolMetrics objects to dicts
+        data = {
+            "timestamp": datetime.now().isoformat(),
+            "max_observed_total": max_observed,
+            "pools": {},
+        }
+
+        for image, metrics in raw_metrics.items():
+            data["pools"][image] = {
+                "ready": getattr(metrics, "ready", 0),
+                "creating": getattr(metrics, "creating", 0),
+                "in_use": getattr(metrics, "in_use", 0),
+                "total_acquires": getattr(metrics, "total_acquires", 0),
+                "acquires_from_pool": getattr(metrics, "acquires_from_pool", 0),
+                "acquires_cold_start": getattr(metrics, "acquires_cold_start", 0),
+                "pool_hit_rate": getattr(metrics, "pool_hit_rate", 0),
+                "avg_acquire_latency_ms": getattr(metrics, "avg_acquire_latency_ms", 0),
+                "scale_up_events": getattr(metrics, "scale_up_events", 0),
+                "scale_down_events": getattr(metrics, "scale_down_events", 0),
+                "failed_creates": getattr(metrics, "failed_creates", 0),
+                "health_check_removals": getattr(metrics, "health_check_removals", 0),
+            }
+
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
+        logger.info(f"Wrote {path}")
+
+    def write_all(
+        self,
+        summary: TestSummary,
+        sessions: List[SessionResult],
+        raw_pool_metrics: Dict[str, Any],
+        max_observed: int,
+    ):
+        """Write all reports."""
+        self.write_summary_json(summary)
+        self.write_summary_txt(summary)
+        self.write_sessions_csv(sessions)
+        self.write_commands_csv(sessions, compress=True)
+        self.write_pool_metrics_json(raw_pool_metrics, max_observed)
+
+        # Print summary to console
+        print("\n" + "=" * 60)
+        print(f"TEST {'PASSED' if summary.passed else 'FAILED'}")
+        print("=" * 60)
+        print(f"Duration: {format_duration(summary.duration_seconds)}")
+        print(f"Sessions: {summary.total_sessions}")
+        print(f"Commands: {summary.total_commands}")
+        print(f"Failures: {summary.total_command_failures}")
+        print(f"Pool hit rate: {summary.pool_hit_rate_overall*100:.1f}%")
+        print(f"Max sandboxes: {summary.max_total_sandboxes_observed}")
+        print(f"Reports: {self.report_dir}")
+        print("=" * 60)

--- a/tests/rigorous_pool_test/run_25cap_4hr.py
+++ b/tests/rigorous_pool_test/run_25cap_4hr.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""
+Rigorous Pool Test - Main Entry Point
+
+A comprehensive stress test for the do-app-sandbox SDK that validates:
+- Command correctness (0 failure tolerance)
+- Pool effectiveness (pool hits vs cold starts)
+- Capacity enforcement (never exceed 25 sandboxes)
+- Lifecycle robustness
+
+Usage:
+    # Smoke test (10 minutes)
+    uv run python -m tests.rigorous_pool_test.run_25cap_4hr --smoke
+
+    # Main 4-hour run
+    uv run python -m tests.rigorous_pool_test.run_25cap_4hr
+
+    # Custom configuration
+    uv run python -m tests.rigorous_pool_test.run_25cap_4hr \
+        --duration-seconds 3600 \
+        --max-total 15 \
+        --concurrency 8
+"""
+
+import argparse
+import asyncio
+import logging
+import signal
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Add src to path for SDK imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from do_app_sandbox import SandboxManager, PoolConfig
+
+from .config import (
+    TestConfig,
+    WatchdogConfig,
+    RetryConfig,
+    SMOKE_CONFIG,
+    MAIN_4HR_CONFIG,
+)
+from .metrics import MetricsCollector, WatchdogMetrics
+from .reporter import Reporter
+from .session import session_worker
+from .utils import setup_logging, format_duration
+from .watchdog import SandboxWatchdog, DisabledWatchdog
+
+
+logger = logging.getLogger("rigorous_pool_test")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Rigorous Pool Test for do-app-sandbox SDK",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Preset modes
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run smoke test (10 minutes, 5 sandboxes, 4 workers)",
+    )
+
+    # Duration
+    parser.add_argument(
+        "--duration-seconds",
+        type=int,
+        default=14400,
+        help="Test duration in seconds",
+    )
+
+    # Sandbox limits
+    parser.add_argument(
+        "--max-total",
+        type=int,
+        default=25,
+        help="Maximum total sandboxes (HARD LIMIT)",
+    )
+
+    # Region and sizing
+    parser.add_argument(
+        "--region",
+        type=str,
+        default="syd1",
+        help="Sandbox region",
+    )
+    parser.add_argument(
+        "--instance-size",
+        type=str,
+        default="basic-xxs",
+        help="Sandbox instance size",
+    )
+
+    # Concurrency
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=12,
+        help="Number of virtual users (workers)",
+    )
+
+    # Pool configuration
+    parser.add_argument(
+        "--python-target-ready",
+        type=int,
+        default=12,
+        help="Python pool target ready count",
+    )
+    parser.add_argument(
+        "--python-max-ready",
+        type=int,
+        default=15,
+        help="Python pool max ready count",
+    )
+    parser.add_argument(
+        "--node-target-ready",
+        type=int,
+        default=0,
+        help="Node pool target ready count (0 to disable)",
+    )
+
+    # Commands
+    parser.add_argument(
+        "--disable-network-commands",
+        action="store_true",
+        help="Disable network-dependent commands",
+    )
+
+    # Reporting
+    parser.add_argument(
+        "--report-dir",
+        type=str,
+        default=None,
+        help="Report output directory (auto-generated if not specified)",
+    )
+
+    # Watchdog
+    parser.add_argument(
+        "--watchdog-interval",
+        type=float,
+        default=10.0,
+        help="Watchdog polling interval in seconds",
+    )
+    parser.add_argument(
+        "--watchdog-grace",
+        type=int,
+        default=2,
+        help="Watchdog grace period (allow brief overage)",
+    )
+    parser.add_argument(
+        "--disable-watchdog",
+        action="store_true",
+        help="Disable external watchdog monitoring",
+    )
+    parser.add_argument(
+        "--enable-emergency-cleanup",
+        action="store_true",
+        help="Enable watchdog emergency cleanup of excess sandboxes",
+    )
+
+    # Logging
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+
+    return parser.parse_args()
+
+
+def build_config(args: argparse.Namespace) -> TestConfig:
+    """Build TestConfig from command line arguments."""
+    if args.smoke:
+        config = SMOKE_CONFIG
+        # Override report_dir to include timestamp
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        config.report_dir = f"tests/artifacts/rigorous_pool_test/smoke_{timestamp}"
+        return config
+
+    return TestConfig(
+        duration_seconds=args.duration_seconds,
+        max_total_sandboxes=args.max_total,
+        region=args.region,
+        instance_size=args.instance_size,
+        concurrency=args.concurrency,
+        python_target_ready=args.python_target_ready,
+        python_max_ready=args.python_max_ready,
+        node_target_ready=args.node_target_ready,
+        enable_network_commands=not args.disable_network_commands,
+        report_dir=args.report_dir,
+        watchdog_enabled=not args.disable_watchdog,
+        watchdog_interval=args.watchdog_interval,
+        watchdog_grace_period=args.watchdog_grace,
+    )
+
+
+async def main():
+    """Main entry point."""
+    args = parse_args()
+    config = build_config(args)
+    retry_config = RetryConfig()
+
+    # Setup logging
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    setup_logging(config.report_dir, level=log_level)
+
+    logger.info("=" * 60)
+    logger.info("RIGOROUS POOL TEST")
+    logger.info("=" * 60)
+    logger.info(f"Duration: {format_duration(config.duration_seconds)}")
+    logger.info(f"Max sandboxes: {config.max_total_sandboxes}")
+    logger.info(f"Concurrency: {config.concurrency}")
+    logger.info(f"Region: {config.region}")
+    logger.info(f"Report dir: {config.report_dir}")
+    logger.info(f"Watchdog: {'enabled' if config.watchdog_enabled else 'disabled'}")
+    logger.info("=" * 60)
+
+    # Pre-flight check: count existing sandbox apps
+    try:
+        import subprocess
+        import json
+        result = subprocess.run(
+            ["doctl", "apps", "list", "--output", "json"],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode == 0:
+            apps = json.loads(result.stdout)
+            existing_sandboxes = [
+                a for a in apps
+                if "sandbox" in a.get("spec", {}).get("name", "").lower()
+            ]
+            if existing_sandboxes:
+                logger.warning(f"PRE-FLIGHT: Found {len(existing_sandboxes)} existing sandbox apps!")
+                for app in existing_sandboxes[:5]:
+                    name = app.get("spec", {}).get("name", "unknown")
+                    created = app.get("created_at", "unknown")
+                    logger.warning(f"  - {name} (created: {created})")
+                if len(existing_sandboxes) > 5:
+                    logger.warning(f"  ... and {len(existing_sandboxes) - 5} more")
+                logger.warning("These will be counted by watchdog but NOT by internal metrics!")
+                logger.warning("Consider cleaning up with: doctl apps list | grep sandbox | awk '{print $1}' | xargs -I{} doctl apps delete {} --force")
+            else:
+                logger.info("PRE-FLIGHT: No existing sandbox apps found - clean environment")
+    except Exception as e:
+        logger.warning(f"PRE-FLIGHT check failed: {e}")
+
+    # Initialize components
+    stop_event = asyncio.Event()
+    metrics_collector = MetricsCollector(max_total=config.max_total_sandboxes)
+    reporter = Reporter(config.report_dir)
+
+    # Setup signal handlers for graceful shutdown
+    def signal_handler(sig, frame):
+        logger.warning(f"Received signal {sig} - initiating shutdown")
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    # Setup watchdog
+    watchdog = None
+    if config.watchdog_enabled:
+        watchdog_config = WatchdogConfig(
+            max_sandboxes=config.max_total_sandboxes,
+            poll_interval=config.watchdog_interval,
+            grace_period=config.watchdog_grace_period,
+        )
+
+        def on_violation():
+            logger.critical("WATCHDOG TRIGGERED - stopping all workers")
+            stop_event.set()
+
+        emergency_cleanup = None
+        if args.enable_emergency_cleanup:
+            async def emergency_cleanup(apps):
+                await watchdog.emergency_delete(apps, config.max_total_sandboxes)
+
+        watchdog = SandboxWatchdog(
+            config=watchdog_config,
+            on_violation=on_violation,
+            on_emergency_cleanup=emergency_cleanup,
+        )
+    else:
+        watchdog = DisabledWatchdog()
+
+    # Build pool configuration
+    pools = {}
+    if config.python_target_ready > 0:
+        pools["python"] = PoolConfig(
+            target_ready=config.python_target_ready,
+            max_ready=config.python_max_ready,
+            idle_timeout=120,
+            health_check_interval=60,
+            on_empty="create",
+            create_retries=3,
+            create_retry_delay=5,
+        )
+
+    if config.node_target_ready > 0:
+        pools["node"] = PoolConfig(
+            target_ready=config.node_target_ready,
+            max_ready=config.node_target_ready + 3,
+            idle_timeout=120,
+            health_check_interval=60,
+            on_empty="create",
+            create_retries=3,
+            create_retry_delay=5,
+        )
+
+    # Initialize manager
+    manager = SandboxManager(
+        max_total_sandboxes=config.max_total_sandboxes,
+        max_concurrent_creates=10,
+        sandbox_defaults={
+            "region": config.region,
+            "instance_size": config.instance_size,
+        },
+        pools=pools,
+    )
+
+    try:
+        # Start manager
+        logger.info("Starting SandboxManager...")
+        await manager.start()
+        logger.info("SandboxManager started")
+
+        # Start metrics collection
+        metrics_collector.start()
+
+        # Start watchdog
+        watchdog_task = asyncio.create_task(watchdog.run(stop_event))
+
+        # Start pool metrics sampling
+        sampling_task = asyncio.create_task(
+            metrics_collector.sample_pool_metrics(
+                manager,
+                interval=5.0,
+                stop_event=stop_event,
+            )
+        )
+
+        # Determine which image to use (default to python)
+        image = "python" if "python" in pools else list(pools.keys())[0]
+
+        # Launch worker tasks
+        logger.info(f"Launching {config.concurrency} workers...")
+        worker_tasks = []
+        for i in range(config.concurrency):
+            task = asyncio.create_task(
+                session_worker(
+                    worker_id=i,
+                    manager=manager,
+                    image=image,
+                    config=config,
+                    retry_config=retry_config,
+                    stop_event=stop_event,
+                    results_callback=metrics_collector.add_session,
+                )
+            )
+            worker_tasks.append(task)
+
+        # Set up duration timer
+        async def duration_timer():
+            try:
+                await asyncio.sleep(config.duration_seconds)
+                logger.info("Test duration elapsed - stopping workers")
+                stop_event.set()
+            except asyncio.CancelledError:
+                pass
+
+        timer_task = asyncio.create_task(duration_timer())
+
+        # Wait for workers to complete
+        logger.info(f"Test running for {format_duration(config.duration_seconds)}...")
+        await asyncio.gather(*worker_tasks, return_exceptions=True)
+
+        # Cancel timer if still running
+        timer_task.cancel()
+        try:
+            await timer_task
+        except asyncio.CancelledError:
+            pass
+
+        # Stop metrics sampling
+        stop_event.set()
+        await sampling_task
+
+        # Stop watchdog
+        watchdog.stop()
+        await watchdog_task
+
+        logger.info("All workers completed")
+
+    except Exception as e:
+        logger.error(f"Test failed with exception: {e}")
+        stop_event.set()
+        raise
+
+    finally:
+        # Shutdown manager
+        logger.info("Shutting down SandboxManager...")
+        try:
+            await manager.shutdown(timeout=60.0, wait_for_active=True)
+            logger.info("SandboxManager shutdown complete")
+        except Exception as e:
+            logger.error(f"Error during shutdown: {e}")
+
+        # Final Cleanup Sweep
+        logger.info("Performing final cleanup sweep...")
+        try:
+            # Re-use watchdog or create temporary one to clean up
+            if watchdog:
+                count, apps = await watchdog.get_sandbox_count()
+                if count > 0:
+                    logger.warning(f"Final Sweep: Found {count} remaining sandboxes. Deleting...")
+                    await watchdog.emergency_delete(apps, keep_count=0)
+                else:
+                    logger.info("Final Sweep: No leftover sandboxes found.")
+        except Exception as e:
+            logger.error(f"Final cleanup failed: {e}")
+
+        # Mark test end
+        metrics_collector.stop()
+
+        # Get final metrics from manager
+        try:
+            raw_pool_metrics = manager.metrics()
+        except Exception:
+            raw_pool_metrics = {}
+
+        # Get watchdog metrics
+        watchdog_metrics = watchdog.get_metrics()
+
+        # Generate summary
+        summary = metrics_collector.get_summary(watchdog_metrics)
+
+        # Write reports
+        reporter.write_all(
+            summary=summary,
+            sessions=metrics_collector.sessions,
+            raw_pool_metrics=raw_pool_metrics,
+            max_observed=metrics_collector.max_observed_total,
+        )
+
+        # Exit with appropriate code
+        if summary.passed:
+            logger.info("TEST PASSED")
+            sys.exit(0)
+        else:
+            logger.error("TEST FAILED")
+            if summary.total_command_failures > 0:
+                logger.error(f"  - {summary.total_command_failures} command failures")
+            if summary.capacity_violations > 0:
+                logger.error(f"  - {summary.capacity_violations} capacity violations")
+            if watchdog_metrics.violation_detected:
+                logger.error("  - Watchdog violation detected")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/rigorous_pool_test/session.py
+++ b/tests/rigorous_pool_test/session.py
@@ -1,0 +1,485 @@
+"""
+Session worker logic for rigorous pool testing.
+
+Handles the full lifecycle of a sandbox session:
+1. Acquire sandbox from pool
+2. Execute commands at controlled rate
+3. Hold for specified duration
+4. Delete sandbox
+5. Return metrics
+"""
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional, Any
+
+from .commands import build_command_list, get_command_budget
+from .config import RetryConfig, TestConfig
+from .utils import (
+    generate_command_delay,
+    generate_hold_time_from_config,
+    generate_session_id,
+    truncate_string,
+)
+
+logger = logging.getLogger("rigorous_pool_test")
+
+
+async def get_current_sandbox_count() -> int:
+    """
+    Get current sandbox count via doctl apps list.
+
+    Returns the actual number of sandbox apps on DigitalOcean.
+    This is the ground truth for capacity enforcement.
+
+    Returns:
+        Number of sandbox apps, or -1 on error
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "doctl", "apps", "list", "--output", "json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+
+        if proc.returncode != 0:
+            logger.warning(f"doctl apps list failed: {stderr.decode()}")
+            return -1
+
+        apps = json.loads(stdout.decode())
+        count = sum(
+            1 for app in apps
+            if "sandbox" in app.get("spec", {}).get("name", "").lower()
+        )
+        return count
+    except Exception as e:
+        logger.warning(f"Failed to get sandbox count: {e}")
+        return -1
+
+
+@dataclass
+class CommandRecord:
+    """Record of a single command execution."""
+
+    session_id: str
+    command_index: int
+    command: str
+    exit_code: int
+    duration_ms: float
+    stdout_snippet: str
+    stderr_snippet: str
+    timestamp: datetime = field(default_factory=datetime.now)
+    retry_count: int = 0
+
+
+@dataclass
+class FailureInfo:
+    """Information about the first command failure."""
+
+    command_index: int
+    command: str
+    exit_code: int
+    stderr_snippet: str
+    timestamp: datetime
+
+
+@dataclass
+class SessionResult:
+    """Complete result of a session."""
+
+    session_id: str
+    image: str
+    from_pool: bool
+    acquire_latency_ms: float
+    sandbox_id: str
+    app_id: str
+    region: str
+    hold_seconds_planned: float
+    hold_seconds_actual: float
+    total_commands_planned: int
+    total_commands_executed: int
+    command_failures_count: int
+    first_failure: Optional[FailureInfo]
+    delete_latency_ms: float
+    commands: List[CommandRecord] = field(default_factory=list)
+    error: Optional[str] = None
+    start_time: datetime = field(default_factory=datetime.now)
+    end_time: Optional[datetime] = None
+
+
+async def execute_command_with_retry(
+    sandbox: Any,
+    command: str,
+    session_id: str,
+    command_index: int,
+    retry_config: RetryConfig,
+) -> CommandRecord:
+    """
+    Execute a single command with retry logic.
+
+    Args:
+        sandbox: AsyncSandbox instance
+        command: Command string to execute
+        session_id: Current session ID
+        command_index: Index of this command in the session
+        retry_config: Retry configuration
+
+    Returns:
+        CommandRecord with execution results
+    """
+    last_error = None
+    retry_count = 0
+
+    for attempt in range(retry_config.exec_retries + 1):
+        start_time = time.perf_counter()
+        try:
+            # Sandbox.exec() is synchronous - wrap in to_thread for async context
+            result = await asyncio.to_thread(sandbox.exec, command)
+            duration_ms = (time.perf_counter() - start_time) * 1000
+
+            return CommandRecord(
+                session_id=session_id,
+                command_index=command_index,
+                command=command,
+                exit_code=result.exit_code,
+                duration_ms=duration_ms,
+                stdout_snippet=truncate_string(result.stdout),
+                stderr_snippet=truncate_string(result.stderr),
+                retry_count=retry_count,
+            )
+
+        except Exception as e:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            last_error = str(e)
+            retry_count += 1
+
+            if attempt < retry_config.exec_retries:
+                logger.warning(
+                    f"Command retry {attempt + 1}/{retry_config.exec_retries}: {command[:50]}... - {e}"
+                )
+                await asyncio.sleep(retry_config.exec_retry_delay)
+
+    # All retries exhausted
+    return CommandRecord(
+        session_id=session_id,
+        command_index=command_index,
+        command=command,
+        exit_code=-1,
+        duration_ms=duration_ms,
+        stdout_snippet="",
+        stderr_snippet=f"EXCEPTION: {last_error}",
+        retry_count=retry_count,
+    )
+
+
+async def delete_sandbox_with_retry(
+    sandbox: Any,
+    retry_config: RetryConfig,
+) -> tuple[bool, float]:
+    """
+    Delete a sandbox with retry logic.
+
+    Args:
+        sandbox: AsyncSandbox instance
+        retry_config: Retry configuration
+
+    Returns:
+        Tuple of (success, duration_ms)
+    """
+    last_error = None
+
+    for attempt in range(retry_config.delete_retries + 1):
+        start_time = time.perf_counter()
+        try:
+            # Sandbox.delete() is synchronous - wrap in to_thread for async context
+            await asyncio.to_thread(sandbox.delete)
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            return True, duration_ms
+
+        except Exception as e:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            last_error = str(e)
+
+            if attempt < retry_config.delete_retries:
+                logger.warning(
+                    f"Delete retry {attempt + 1}/{retry_config.delete_retries}: {e}"
+                )
+                await asyncio.sleep(retry_config.delete_retry_delay)
+
+    logger.error(f"Failed to delete sandbox after retries: {last_error}")
+    return False, duration_ms
+
+
+async def run_session(
+    manager: Any,
+    image: str,
+    session_id: str,
+    hold_time_sec: int,
+    config: TestConfig,
+    retry_config: RetryConfig,
+    stop_event: asyncio.Event,
+) -> SessionResult:
+    """
+    Run a complete sandbox session.
+
+    Args:
+        manager: SandboxManager instance
+        image: Image name (python/node)
+        session_id: Unique session identifier
+        hold_time_sec: How long to hold the sandbox
+        config: Test configuration
+        retry_config: Retry configuration
+        stop_event: Event to signal early termination
+
+    Returns:
+        SessionResult with all metrics
+    """
+    result = SessionResult(
+        session_id=session_id,
+        image=image,
+        from_pool=False,
+        acquire_latency_ms=0,
+        sandbox_id="",
+        app_id="",
+        region=config.region,
+        hold_seconds_planned=hold_time_sec,
+        hold_seconds_actual=0,
+        total_commands_planned=get_command_budget(hold_time_sec),
+        total_commands_executed=0,
+        command_failures_count=0,
+        first_failure=None,
+        delete_latency_ms=0,
+    )
+
+    sandbox = None
+    session_start = time.perf_counter()
+
+    try:
+        # 1. Check capacity before acquiring (ground truth from doctl)
+        max_sandboxes = config.max_total_sandboxes
+        max_wait_seconds = 60  # Max time to wait for capacity
+        wait_start = time.perf_counter()
+
+        while True:
+            current_count = await get_current_sandbox_count()
+            if current_count < 0:
+                # doctl failed, proceed anyway (let SDK handle it)
+                logger.warning(f"Session {session_id}: Could not check capacity, proceeding")
+                break
+            elif current_count < max_sandboxes:
+                # Capacity available
+                logger.debug(f"Session {session_id}: Capacity OK ({current_count}/{max_sandboxes})")
+                break
+            else:
+                # At capacity - wait and retry
+                waited = time.perf_counter() - wait_start
+                if waited > max_wait_seconds:
+                    logger.warning(
+                        f"Session {session_id}: Capacity wait timeout ({current_count}/{max_sandboxes}), "
+                        f"skipping this acquire"
+                    )
+                    result.error = f"Capacity wait timeout ({current_count}/{max_sandboxes})"
+                    result.end_time = datetime.now()
+                    return result
+
+                if stop_event.is_set():
+                    result.error = "Stopped while waiting for capacity"
+                    result.end_time = datetime.now()
+                    return result
+
+                logger.debug(
+                    f"Session {session_id}: At capacity ({current_count}/{max_sandboxes}), "
+                    f"waiting 2s..."
+                )
+                await asyncio.sleep(2)
+
+        # 2. Acquire sandbox
+        acquire_start = time.perf_counter()
+        sandbox = await manager.acquire(image)
+        result.acquire_latency_ms = (time.perf_counter() - acquire_start) * 1000
+
+        # Record sandbox info
+        result.from_pool = getattr(sandbox, "_from_pool", False)
+        result.sandbox_id = getattr(sandbox, "component", "unknown")
+        result.app_id = getattr(sandbox, "app_id", "unknown")
+
+        source = "POOL" if result.from_pool else "COLD"
+        logger.info(
+            f"Worker {session_id.split('_')[0]}: Acquired {source} sandbox ({result.acquire_latency_ms:.0f}ms) "
+            f"for session {session_id}"
+        )
+
+        # 3. Build command list
+        commands = build_command_list(
+            image=image,
+            total_commands=result.total_commands_planned,
+            enable_network=config.enable_network_commands,
+        )
+
+        # 4. Execute commands at controlled rate
+        command_start_time = time.perf_counter()
+        hold_deadline = command_start_time + hold_time_sec
+
+        logger.info(
+            f"Worker {session_id.split('_')[0]}: Running session {session_id} "
+            f"(hold={hold_time_sec}s, cmds={len(commands)})"
+        )
+
+        for i, command in enumerate(commands):
+            # Check for early termination
+            if stop_event.is_set():
+                logger.info(f"Session {session_id}: Early termination at command {i}")
+                break
+
+            # Check if we've exceeded hold time
+            if time.perf_counter() > hold_deadline:
+                logger.debug(
+                    f"Session {session_id}: Hold time exceeded at command {i}/{len(commands)}"
+                )
+                break
+
+            # Execute command
+            cmd_record = await execute_command_with_retry(
+                sandbox=sandbox,
+                command=command,
+                session_id=session_id,
+                command_index=i,
+                retry_config=retry_config,
+            )
+            result.commands.append(cmd_record)
+            result.total_commands_executed += 1
+
+            # Track failures
+            if cmd_record.exit_code != 0:
+                result.command_failures_count += 1
+                if result.first_failure is None:
+                    result.first_failure = FailureInfo(
+                        command_index=i,
+                        command=command,
+                        exit_code=cmd_record.exit_code,
+                        stderr_snippet=cmd_record.stderr_snippet,
+                        timestamp=datetime.now(),
+                    )
+                    logger.warning(
+                        f"Session {session_id}: Command failure at index {i}: "
+                        f"exit_code={cmd_record.exit_code}, cmd={command[:50]}..."
+                    )
+
+            # Log progress every 50 commands
+            if (i + 1) % 50 == 0:
+                logger.info(
+                    f"Session {session_id}: Progress {i + 1}/{len(commands)} commands "
+                    f"({result.command_failures_count} failures)"
+                )
+
+            # Random delay between commands
+            if i < len(commands) - 1:
+                delay = generate_command_delay()
+                await asyncio.sleep(delay)
+
+        # 5. Hold remaining time if we finished commands early
+        remaining_time = hold_deadline - time.perf_counter()
+        if remaining_time > 0 and not stop_event.is_set():
+            logger.debug(
+                f"Session {session_id}: Holding for {remaining_time:.1f}s more"
+            )
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(), timeout=remaining_time
+                )
+            except asyncio.TimeoutError:
+                pass  # Normal - hold time elapsed
+
+        result.hold_seconds_actual = time.perf_counter() - session_start
+
+    except Exception as e:
+        result.error = str(e)
+        logger.error(f"Session {session_id}: Error - {e}")
+
+    finally:
+        # 6. Delete sandbox
+        if sandbox is not None:
+            success, delete_latency = await delete_sandbox_with_retry(
+                sandbox, retry_config
+            )
+            result.delete_latency_ms = delete_latency
+            if not success:
+                result.error = (result.error or "") + "; Delete failed"
+
+            # CRITICAL: Release the quota in the manager
+            # This decrements the in-use counter so new sandboxes can be created
+            manager.release(sandbox, image)
+            
+            logger.info(
+                f"Worker {session_id.split('_')[0]}: Released sandbox for session {session_id} "
+                f"(held {result.hold_seconds_actual:.1f}s)"
+            )
+
+        result.end_time = datetime.now()
+
+    # logger.info(
+    #    f"Session {session_id}: Completed - "
+    #    f"commands={result.total_commands_executed}/{result.total_commands_planned}, "
+    #    f"failures={result.command_failures_count}, "
+    #    f"hold={result.hold_seconds_actual:.1f}s/{result.hold_seconds_planned}s"
+    # )
+
+    return result
+
+
+async def session_worker(
+    worker_id: int,
+    manager: Any,
+    image: str,
+    config: TestConfig,
+    retry_config: RetryConfig,
+    stop_event: asyncio.Event,
+    results_callback: callable,
+) -> int:
+    """
+    Worker loop that continuously runs sessions until stop_event is set.
+
+    Args:
+        worker_id: Unique worker identifier
+        manager: SandboxManager instance
+        image: Image name to use
+        config: Test configuration
+        retry_config: Retry configuration
+        stop_event: Event to signal termination
+        results_callback: Callback to report session results
+
+    Returns:
+        Number of sessions completed
+    """
+    session_num = 0
+    logger.info(f"Worker {worker_id}: Starting")
+
+    while not stop_event.is_set():
+        session_num += 1
+        session_id = generate_session_id(worker_id, session_num)
+        hold_time = generate_hold_time_from_config(config.hold_time_min, config.hold_time_max)
+
+        logger.info(
+            f"Worker {worker_id}: Starting session {session_id} "
+            f"(hold={hold_time}s, budget={get_command_budget(hold_time)} cmds)"
+        )
+
+        result = await run_session(
+            manager=manager,
+            image=image,
+            session_id=session_id,
+            hold_time_sec=hold_time,
+            config=config,
+            retry_config=retry_config,
+            stop_event=stop_event,
+        )
+
+        results_callback(result)
+
+    logger.info(f"Worker {worker_id}: Stopped after {session_num} sessions")
+    return session_num

--- a/tests/rigorous_pool_test/utils.py
+++ b/tests/rigorous_pool_test/utils.py
@@ -1,0 +1,230 @@
+"""
+Utility functions for rigorous pool testing.
+"""
+
+import asyncio
+import logging
+import random
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from .config import HoldTimeConfig
+
+
+def setup_logging(
+    report_dir: str,
+    level: int = logging.INFO,
+    console: bool = True,
+) -> logging.Logger:
+    """
+    Set up logging for the test run.
+
+    Args:
+        report_dir: Directory for log file
+        level: Logging level
+        console: Whether to also log to console
+
+    Returns:
+        Configured logger
+    """
+    Path(report_dir).mkdir(parents=True, exist_ok=True)
+
+    logger = logging.getLogger("rigorous_pool_test")
+    logger.setLevel(level)
+    logger.handlers.clear()
+
+    # File handler
+    log_file = Path(report_dir) / "test.log"
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setLevel(level)
+    file_formatter = logging.Formatter(
+        "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    file_handler.setFormatter(file_formatter)
+    logger.addHandler(file_handler)
+
+    # Console handler
+    if console:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(level)
+        console_formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)-8s | %(message)s",
+            datefmt="%H:%M:%S",
+        )
+        console_handler.setFormatter(console_formatter)
+        logger.addHandler(console_handler)
+
+    return logger
+
+
+@dataclass
+class TimingResult:
+    """Result of a timed operation."""
+
+    duration_ms: float
+    start_time: datetime
+    end_time: datetime
+
+
+@contextmanager
+def timed_operation():
+    """
+    Context manager for timing operations.
+
+    Yields a TimingResult that gets populated on exit.
+
+    Usage:
+        with timed_operation() as timing:
+            # do something
+        print(f"Took {timing.duration_ms}ms")
+    """
+    result = TimingResult(
+        duration_ms=0,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    start = time.perf_counter()
+    try:
+        yield result
+    finally:
+        end = time.perf_counter()
+        result.duration_ms = (end - start) * 1000
+        result.end_time = datetime.now()
+
+
+async def timed_async_operation():
+    """
+    Async context manager for timing operations.
+
+    Usage:
+        async with timed_async_operation() as timing:
+            await do_something()
+        print(f"Took {timing.duration_ms}ms")
+    """
+
+    class AsyncTimedContext:
+        def __init__(self):
+            self.result = TimingResult(
+                duration_ms=0,
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+            )
+            self._start = 0
+
+        async def __aenter__(self):
+            self.result.start_time = datetime.now()
+            self._start = time.perf_counter()
+            return self.result
+
+        async def __aexit__(self, *args):
+            end = time.perf_counter()
+            self.result.duration_ms = (end - self._start) * 1000
+            self.result.end_time = datetime.now()
+
+    return AsyncTimedContext()
+
+
+def generate_hold_time(config: Optional[HoldTimeConfig] = None) -> int:
+    """
+    Generate a random hold time based on distribution.
+
+    Args:
+        config: Hold time configuration (uses defaults if None)
+
+    Returns:
+        Hold time in seconds
+    """
+    if config is None:
+        config = HoldTimeConfig()
+
+    # Roll for distribution bucket
+    roll = random.random()
+
+    if roll < config.short_weight:
+        # Short hold (40%): 5-10 minutes
+        return random.randint(config.short_min, config.short_max)
+    elif roll < config.short_weight + config.medium_weight:
+        # Medium hold (40%): 10-20 minutes
+        return random.randint(config.medium_min, config.medium_max)
+    else:
+        # Long hold (20%): 20-60 minutes
+        return random.randint(config.long_min, config.long_max)
+
+
+def generate_hold_time_from_config(hold_min: int, hold_max: int) -> int:
+    """
+    Generate a random hold time between min and max.
+
+    Args:
+        hold_min: Minimum hold time in seconds
+        hold_max: Maximum hold time in seconds
+
+    Returns:
+        Hold time in seconds
+    """
+    return random.randint(hold_min, hold_max)
+
+
+def generate_command_delay() -> float:
+    """
+    Generate a random delay between commands.
+
+    Returns:
+        Delay in seconds (0.5-2.0)
+    """
+    return random.uniform(0.5, 2.0)
+
+
+def truncate_string(s: str, max_len: int = 200) -> str:
+    """Truncate a string to max length with ellipsis."""
+    if len(s) <= max_len:
+        return s
+    return s[: max_len - 3] + "..."
+
+
+def generate_session_id(worker_id: int, session_num: int) -> str:
+    """Generate a unique session ID."""
+    timestamp = datetime.now().strftime("%H%M%S")
+    return f"w{worker_id:02d}_s{session_num:04d}_{timestamp}"
+
+
+def format_duration(seconds: float) -> str:
+    """Format duration in human-readable form."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    elif seconds < 3600:
+        minutes = seconds / 60
+        return f"{minutes:.1f}m"
+    else:
+        hours = seconds / 3600
+        return f"{hours:.2f}h"
+
+
+def percentile(data: list, p: float) -> float:
+    """
+    Calculate percentile of a list of numbers.
+
+    Args:
+        data: List of numbers
+        p: Percentile (0-100)
+
+    Returns:
+        Value at the given percentile
+    """
+    if not data:
+        return 0.0
+
+    sorted_data = sorted(data)
+    k = (len(sorted_data) - 1) * (p / 100)
+    f = int(k)
+    c = f + 1 if f + 1 < len(sorted_data) else f
+
+    if f == c:
+        return sorted_data[f]
+
+    return sorted_data[f] * (c - k) + sorted_data[c] * (k - f)

--- a/tests/rigorous_pool_test/watchdog.py
+++ b/tests/rigorous_pool_test/watchdog.py
@@ -1,0 +1,283 @@
+"""
+External sandbox watchdog for rigorous pool testing.
+
+Monitors actual live sandbox count via `doctl apps list`,
+completely independent of SandboxManager internals.
+
+Provides a fail-safe to ensure we NEVER exceed the sandbox limit.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+from typing import Callable, List, Optional, Tuple
+
+from .config import WatchdogConfig
+from .metrics import WatchdogMetrics
+
+logger = logging.getLogger("rigorous_pool_test")
+
+
+class SandboxWatchdog:
+    """
+    External watchdog that monitors `doctl apps list` for sandbox count.
+
+    Runs independently of SandboxManager - uses actual DO API state.
+    If count exceeds limit, triggers emergency shutdown.
+    """
+
+    def __init__(
+        self,
+        config: WatchdogConfig,
+        on_violation: Callable[[], None],
+        on_emergency_cleanup: Optional[Callable[[List[str]], None]] = None,
+    ):
+        """
+        Initialize the watchdog.
+
+        Args:
+            config: Watchdog configuration
+            on_violation: Callback to trigger test shutdown
+            on_emergency_cleanup: Optional callback to delete excess sandboxes
+        """
+        self.config = config
+        self.on_violation = on_violation
+        self.on_emergency_cleanup = on_emergency_cleanup
+
+        self._running = False
+        self._violation_detected = False
+        self._max_observed = 0
+        self._check_count = 0
+        self._emergency_deletions = 0
+        self._last_count = 0
+
+    async def get_sandbox_count(self) -> Tuple[int, List[dict]]:
+        """
+        Run `doctl apps list --output json` and count sandbox apps.
+
+        Returns:
+            Tuple of (count, list_of_app_dicts)
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "doctl", "apps", "list", "--output", "json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+
+            if proc.returncode != 0:
+                logger.error(f"doctl apps list failed: {stderr.decode()}")
+                return -1, []
+
+            apps = json.loads(stdout.decode())
+
+            # Filter to sandbox apps only
+            sandbox_apps = []
+            for app in apps:
+                spec = app.get("spec", {})
+                name = spec.get("name", "").lower()
+                if self.config.sandbox_name_pattern.lower() in name:
+                    sandbox_apps.append(app)
+
+            return len(sandbox_apps), sandbox_apps
+
+        except FileNotFoundError:
+            logger.error("doctl not found - watchdog disabled")
+            return -1, []
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse doctl output: {e}")
+            return -1, []
+        except Exception as e:
+            logger.error(f"Watchdog check failed: {e}")
+            return -1, []
+
+    async def emergency_delete(self, apps: List[dict], keep_count: int = 25):
+        """
+        Emergency deletion of excess sandboxes.
+
+        Deletes oldest sandboxes first until we're at keep_count.
+
+        Args:
+            apps: List of app dicts from doctl
+            keep_count: Number of sandboxes to keep
+        """
+        excess = len(apps) - keep_count
+        if excess <= 0:
+            return
+
+        logger.critical(f"EMERGENCY: Deleting {excess} excess sandboxes")
+
+        # Sort by created_at to delete oldest first
+        sorted_apps = sorted(
+            apps,
+            key=lambda a: a.get("created_at", ""),
+        )
+
+        for app in sorted_apps[:excess]:
+            app_id = app.get("id")
+            app_name = app.get("spec", {}).get("name", "unknown")
+
+            try:
+                logger.warning(f"Emergency deleting: {app_name} ({app_id})")
+
+                proc = await asyncio.create_subprocess_exec(
+                    "doctl", "apps", "delete", app_id, "--force",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await proc.communicate()
+
+                if proc.returncode == 0:
+                    self._emergency_deletions += 1
+                    logger.warning(f"Emergency deleted: {app_name}")
+                else:
+                    logger.error(f"Failed to delete {app_name}")
+
+            except Exception as e:
+                logger.error(f"Exception deleting {app_name}: {e}")
+
+    async def run(self, stop_event: asyncio.Event):
+        """
+        Main watchdog loop. Runs until stop_event is set.
+
+        Args:
+            stop_event: Event to signal termination
+        """
+        self._running = True
+        logger.info(
+            f"Watchdog started: monitoring for max {self.config.max_sandboxes} sandboxes "
+            f"(pattern={self.config.sandbox_name_pattern}, interval={self.config.poll_interval}s, "
+            f"grace={self.config.grace_period})"
+        )
+
+        while not stop_event.is_set() and self._running:
+            try:
+                count, apps = await self.get_sandbox_count()
+                self._check_count += 1
+
+                if count >= 0:  # Valid count
+                    self._last_count = count
+                    self._max_observed = max(self._max_observed, count)
+
+                    hard_limit = self.config.max_sandboxes + self.config.grace_period
+
+                    if count > hard_limit:
+                        # CRITICAL VIOLATION - trigger emergency shutdown
+                        logger.critical(
+                            f"WATCHDOG VIOLATION: {count} sandboxes detected "
+                            f"(limit: {self.config.max_sandboxes}, grace: {self.config.grace_period})"
+                        )
+                        self._violation_detected = True
+
+                        # Trigger test shutdown
+                        self.on_violation()
+
+                        # Emergency cleanup if configured
+                        if self.on_emergency_cleanup:
+                            await self.emergency_delete(apps, self.config.max_sandboxes)
+
+                        # Continue monitoring to track cleanup
+
+                    elif count > self.config.max_sandboxes:
+                        # Warning - over limit but within grace period
+                        logger.warning(
+                            f"Watchdog warning: {count} sandboxes "
+                            f"(limit: {self.config.max_sandboxes}+{self.config.grace_period})"
+                        )
+                    else:
+                        # Normal - under limit
+                        if self._check_count % 6 == 0:  # Log every ~minute
+                            logger.info(f"Watchdog: {count} sandboxes OK (max observed: {self._max_observed})")
+
+            except Exception as e:
+                logger.error(f"Watchdog iteration failed: {e}")
+
+            # Wait for next poll
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(),
+                    timeout=self.config.poll_interval,
+                )
+            except asyncio.TimeoutError:
+                pass  # Normal - continue polling
+
+        self._running = False
+        logger.info(
+            f"Watchdog stopped. Max observed: {self._max_observed}, "
+            f"Checks: {self._check_count}, Emergency deletions: {self._emergency_deletions}"
+        )
+
+    def stop(self):
+        """Signal the watchdog to stop."""
+        self._running = False
+
+    @property
+    def violation_detected(self) -> bool:
+        """Whether a violation was detected."""
+        return self._violation_detected
+
+    @property
+    def max_observed(self) -> int:
+        """Maximum sandbox count observed."""
+        return self._max_observed
+
+    @property
+    def check_count(self) -> int:
+        """Number of checks performed."""
+        return self._check_count
+
+    @property
+    def emergency_deletions(self) -> int:
+        """Number of emergency deletions performed."""
+        return self._emergency_deletions
+
+    @property
+    def last_count(self) -> int:
+        """Last observed sandbox count."""
+        return self._last_count
+
+    def get_metrics(self) -> WatchdogMetrics:
+        """Get current watchdog metrics."""
+        return WatchdogMetrics(
+            enabled=True,
+            violation_detected=self._violation_detected,
+            max_observed_via_doctl=self._max_observed,
+            total_checks=self._check_count,
+            emergency_deletions=self._emergency_deletions,
+        )
+
+
+class DisabledWatchdog:
+    """Placeholder watchdog when monitoring is disabled."""
+
+    def __init__(self):
+        pass
+
+    async def run(self, stop_event: asyncio.Event):
+        """No-op run."""
+        logger.info("Watchdog disabled - not monitoring")
+        await stop_event.wait()
+
+    def stop(self):
+        pass
+
+    @property
+    def violation_detected(self) -> bool:
+        return False
+
+    @property
+    def max_observed(self) -> int:
+        return 0
+
+    @property
+    def check_count(self) -> int:
+        return 0
+
+    @property
+    def emergency_deletions(self) -> int:
+        return 0
+
+    def get_metrics(self) -> WatchdogMetrics:
+        return WatchdogMetrics(enabled=False)

--- a/tests/test_connection_stability.py
+++ b/tests/test_connection_stability.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Test for WebSocket connection stability and throughput.
+
+This test creates a single sandbox and issues commands continuously for a specified duration.
+It measures:
+- Connection stability (failures)
+- Throughput (commands per second)
+- Latency (avg time per command)
+"""
+
+import argparse
+import sys
+import time
+import os
+from datetime import datetime
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from do_app_sandbox import Sandbox
+
+def main():
+    parser = argparse.ArgumentParser(description="Test WebSocket connection stability.")
+    parser.add_argument("--image", default="python", help="Sandbox image to use")
+    parser.add_argument("--duration", type=int, default=300, help="Test duration in seconds (default: 300)")
+    parser.add_argument("--region", default="syd1", help="Region to create sandbox in")
+    parser.add_argument("--command", default="echo test", help="Command to execute repeatedly")
+    args = parser.parse_args()
+
+    print(f"Starting Connection Stability Test")
+    print(f"  Image: {args.image}")
+    print(f"  Duration: {args.duration}s")
+    print(f"  Region: {args.region}")
+    print(f"  Command: {args.command}")
+    print("-" * 60)
+
+    sandbox = None
+    try:
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] Creating sandbox...")
+        start_create = time.time()
+        sandbox = Sandbox.create(
+            image=args.image,
+            region=args.region,
+            wait_ready=True,
+            timeout=300
+        )
+        create_time = time.time() - start_create
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] Sandbox created in {create_time:.1f}s: {sandbox.app_id}")
+
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] Starting command loop for {args.duration}s...")
+        
+        start_test = time.time()
+        end_time = start_test + args.duration
+        
+        total_commands = 0
+        success_count = 0
+        failure_count = 0
+        latencies = []
+
+        while time.time() < end_time:
+            cmd_start = time.time()
+            try:
+                result = sandbox.exec(args.command)
+                cmd_duration = time.time() - cmd_start
+                latencies.append(cmd_duration)
+                
+                if result.success:
+                    success_count += 1
+                else:
+                    failure_count += 1
+                    print(f"Command failed: {result.stderr}")
+            except Exception as e:
+                print(f"Execution exception: {e}")
+                failure_count += 1
+            
+            total_commands += 1
+            
+            # Print progress every 10 seconds or 100 commands
+            if total_commands % 100 == 0:
+                 elapsed = time.time() - start_test
+                 rate = total_commands / elapsed
+                 print(f"  Progress: {total_commands} cmds | {elapsed:.1f}s | {rate:.1f} cmd/s | Failures: {failure_count}")
+
+        total_time = time.time() - start_test
+        avg_latency = sum(latencies) / len(latencies) if latencies else 0
+        throughput = total_commands / total_time if total_time > 0 else 0
+
+        print("-" * 60)
+        print("RESULTS")
+        print("-" * 60)
+        print(f"Total Duration: {total_time:.1f}s")
+        print(f"Total Commands: {total_commands}")
+        print(f"Successful:     {success_count} ({success_count/total_commands*100:.1f}%)")
+        print(f"Failed:         {failure_count} ({failure_count/total_commands*100:.1f}%)")
+        print(f"Throughput:     {throughput:.1f} cmds/sec")
+        print(f"Avg Latency:    {avg_latency*1000:.1f} ms")
+        print(f"Min Latency:    {min(latencies)*1000:.1f} ms" if latencies else "Min Latency: N/A")
+        print(f"Max Latency:    {max(latencies)*1000:.1f} ms" if latencies else "Max Latency: N/A")
+        
+        if failure_count == 0:
+            print("\nSTATUS: PASS")
+        else:
+            print("\nSTATUS: FAIL (failures detected)")
+
+    except Exception as e:
+        print(f"\nCRITICAL ERROR: {e}")
+        import traceback
+        traceback.print_exc()
+    finally:
+        if sandbox:
+            print(f"\n[{datetime.now().strftime('%H:%M:%S')}] Deleting sandbox...")
+            sandbox.delete()
+            print("Sandbox deleted.")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pool_basic_integration.py
+++ b/tests/test_pool_basic_integration.py
@@ -1,0 +1,236 @@
+"""
+Basic integration test for SandboxManager pool pre-warming and replenishment.
+
+This test verifies the fundamental pool functionality:
+1. Pool pre-warms sandboxes to target_ready count
+2. Acquisitions from warm pool have ~zero latency (from_pool=True)
+3. Pool automatically replenishes after sandboxes are acquired
+4. Subsequent acquisitions also come from pool
+
+Run with:
+    python -m pytest tests/test_pool_basic_integration.py -v -s
+
+Or directly:
+    python tests/test_pool_basic_integration.py
+"""
+
+import asyncio
+import time
+from typing import List
+
+from do_app_sandbox import Sandbox, SandboxManager, PoolConfig
+
+
+# Configuration
+IMAGE = "python"
+TARGET_READY = 3
+WARM_UP_TIMEOUT = 180.0  # 3 minutes for initial warm-up
+
+
+def print_header(text: str) -> None:
+    """Print a formatted header."""
+    print(f"\n{'='*60}")
+    print(f"  {text}")
+    print(f"{'='*60}")
+
+
+def print_step(step: int, text: str) -> None:
+    """Print a step marker."""
+    print(f"\n[Step {step}] {text}")
+
+
+def print_info(text: str) -> None:
+    """Print info message."""
+    print(f"  ℹ️  {text}")
+
+
+def print_success(text: str) -> None:
+    """Print success message."""
+    print(f"  ✅ {text}")
+
+
+def print_metrics(manager: SandboxManager, image: str) -> None:
+    """Print current pool metrics."""
+    metrics = manager.metrics().get(image)
+    if metrics:
+        print(f"  📊 Pool Metrics:")
+        print(f"     - Ready: {metrics.ready}")
+        print(f"     - Creating: {metrics.creating}")
+        print(f"     - In Use: {metrics.in_use}")
+        print(f"     - Total Acquires: {metrics.total_acquires}")
+        print(f"     - From Pool: {metrics.acquires_from_pool}")
+        print(f"     - Pool Hit Rate: {metrics.pool_hit_rate:.1%}")
+        if metrics.avg_acquire_latency_ms:
+            print(f"     - Avg Acquire Latency: {metrics.avg_acquire_latency_ms:.1f}ms")
+
+
+async def test_pool_prewarm_and_replenish() -> None:
+    """
+    Integration test for pool pre-warming and automatic replenishment.
+
+    This test:
+    1. Creates a pool with target_ready=3
+    2. Waits for warm-up (3 sandboxes pre-created)
+    3. Acquires 3 sandboxes, verifying each came from pool
+    4. Waits for pool to replenish
+    5. Acquires 3 more sandboxes, verifying they also came from pool
+    6. Cleans up all resources
+    """
+    print_header("Pool Pre-Warming & Replenishment Integration Test")
+    print_info(f"Image: {IMAGE}")
+    print_info(f"Target Ready: {TARGET_READY}")
+
+    sandboxes: List[Sandbox] = []
+    manager = None
+
+    try:
+        # Step 1: Create manager with pool configuration
+        print_step(1, "Creating SandboxManager with pool configuration")
+        manager = SandboxManager(
+            pools={IMAGE: PoolConfig(target_ready=TARGET_READY, max_ready=TARGET_READY + 2)},
+        )
+        print_success(f"Manager created with target_ready={TARGET_READY}")
+
+        # Step 2: Start the manager
+        print_step(2, "Starting manager (spawns background replenishment)")
+        start_time = time.time()
+        await manager.start()
+        print_success(f"Manager started in {time.time() - start_time:.2f}s")
+
+        # Step 3: Wait for warm-up
+        print_step(3, f"Waiting for pool warm-up (target: {TARGET_READY} sandboxes)")
+        print_info("This may take 1-2 minutes for sandbox creation...")
+        warm_start = time.time()
+        await manager.warm_up(timeout=WARM_UP_TIMEOUT)
+        warm_duration = time.time() - warm_start
+        print_success(f"Pool warmed up in {warm_duration:.1f}s")
+        print_metrics(manager, IMAGE)
+
+        # Step 4: Acquire 3 sandboxes (should all come from pool)
+        print_step(4, f"Acquiring {TARGET_READY} sandboxes (should be instant from pool)")
+        first_batch: List[Sandbox] = []
+
+        for i in range(TARGET_READY):
+            acquire_start = time.time()
+            sandbox = await manager.acquire(image=IMAGE)
+            acquire_ms = (time.time() - acquire_start) * 1000
+
+            from_pool = getattr(sandbox, '_from_pool', None)
+            source = "POOL" if from_pool else "COLD START"
+
+            print_info(f"Sandbox {i+1}: acquired in {acquire_ms:.1f}ms [{source}]")
+            print_info(f"  App ID: {sandbox.app_id}")
+
+            if not from_pool:
+                print(f"  ⚠️  WARNING: Expected from pool but got cold start!")
+
+            first_batch.append(sandbox)
+            sandboxes.append(sandbox)
+
+        print_metrics(manager, IMAGE)
+
+        # Verify all came from pool
+        pool_hits = sum(1 for sb in first_batch if getattr(sb, '_from_pool', False))
+        if pool_hits == TARGET_READY:
+            print_success(f"All {TARGET_READY} sandboxes acquired from pool (zero cold starts)")
+        else:
+            print(f"  ⚠️  Only {pool_hits}/{TARGET_READY} came from pool")
+
+        # Step 5: Wait for pool to replenish
+        print_step(5, "Waiting for pool to replenish after acquisitions")
+        print_info(f"Pool should auto-replenish back to {TARGET_READY} sandboxes...")
+        replenish_start = time.time()
+        await manager.warm_up(timeout=WARM_UP_TIMEOUT)
+        replenish_duration = time.time() - replenish_start
+        print_success(f"Pool replenished in {replenish_duration:.1f}s")
+        print_metrics(manager, IMAGE)
+
+        # Step 6: Acquire 3 more sandboxes (should also come from pool)
+        print_step(6, f"Acquiring {TARGET_READY} more sandboxes (verifying replenishment)")
+        second_batch: List[Sandbox] = []
+
+        for i in range(TARGET_READY):
+            acquire_start = time.time()
+            sandbox = await manager.acquire(image=IMAGE)
+            acquire_ms = (time.time() - acquire_start) * 1000
+
+            from_pool = getattr(sandbox, '_from_pool', None)
+            source = "POOL" if from_pool else "COLD START"
+
+            print_info(f"Sandbox {TARGET_READY + i + 1}: acquired in {acquire_ms:.1f}ms [{source}]")
+            print_info(f"  App ID: {sandbox.app_id}")
+
+            if not from_pool:
+                print(f"  ⚠️  WARNING: Expected from pool but got cold start!")
+
+            second_batch.append(sandbox)
+            sandboxes.append(sandbox)
+
+        print_metrics(manager, IMAGE)
+
+        # Verify second batch also came from pool
+        pool_hits_2 = sum(1 for sb in second_batch if getattr(sb, '_from_pool', False))
+        if pool_hits_2 == TARGET_READY:
+            print_success(f"All {TARGET_READY} replenished sandboxes acquired from pool")
+        else:
+            print(f"  ⚠️  Only {pool_hits_2}/{TARGET_READY} came from pool after replenishment")
+
+        # Step 7: Delete all acquired sandboxes
+        print_step(7, f"Deleting {len(sandboxes)} acquired sandboxes")
+        for i, sandbox in enumerate(sandboxes):
+            print_info(f"Deleting sandbox {i+1}/{len(sandboxes)}: {sandbox.app_id}")
+            try:
+                sandbox.delete()
+                print_success(f"Deleted {sandbox.app_id}")
+            except Exception as e:
+                print(f"  ⚠️  Failed to delete {sandbox.app_id}: {e}")
+        sandboxes.clear()
+
+        # Step 8: Shutdown manager (cleans up pool)
+        print_step(8, "Shutting down manager (drains remaining pool)")
+        await manager.shutdown()
+        print_success("Manager shutdown complete")
+
+        # Final summary
+        print_header("Test Summary")
+        total_acquires = TARGET_READY * 2
+        total_pool_hits = pool_hits + pool_hits_2
+        print_info(f"Total Acquisitions: {total_acquires}")
+        print_info(f"Pool Hits: {total_pool_hits}")
+        print_info(f"Cold Starts: {total_acquires - total_pool_hits}")
+        print_info(f"Pool Hit Rate: {total_pool_hits/total_acquires:.1%}")
+
+        if total_pool_hits == total_acquires:
+            print_success("TEST PASSED: All acquisitions came from pool")
+        else:
+            print(f"\n  ⚠️  TEST INCOMPLETE: {total_acquires - total_pool_hits} cold starts detected")
+
+    except Exception as e:
+        print(f"\n❌ ERROR: {e}")
+        raise
+    finally:
+        # Cleanup: delete any remaining sandboxes
+        if sandboxes:
+            print(f"\n🧹 Cleaning up {len(sandboxes)} remaining sandboxes...")
+            for sandbox in sandboxes:
+                try:
+                    sandbox.delete()
+                except Exception:
+                    pass
+
+        # Cleanup: shutdown manager if still running
+        if manager and not manager._shutdown:
+            print("🧹 Shutting down manager...")
+            try:
+                await manager.shutdown()
+            except Exception:
+                pass
+
+
+async def main():
+    """Run the integration test."""
+    await test_pool_prewarm_and_replenish()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Fixes #17

This PR addresses several race conditions and edge cases discovered during rigorous integration testing of the `SandboxManager` pool functionality:

- **Pool pre-warming not starting**: `_is_active` was `False` until first `acquire()`, preventing pre-warming
- **TOCTOU race condition**: Multiple tasks could exceed limits due to check-then-increment pattern
- **Replenish loop over-creation**: Non-blocking `create_task()` allowed multiple cycles to spawn duplicates
- **Orphaned sandboxes during shutdown**: In-flight creations weren't tracked or awaited
- **TimeoutError on graceful shutdown**: `CancelledError` not properly handled in creation methods

## Changes

### `src/do_app_sandbox/manager.py`
- Set `_is_active = True` in `start()` for immediate pre-warming
- Pessimistic reservation pattern: increment `_creating_count` before checking limits
- Track creation tasks in `_creation_tasks` set with done callbacks
- Cancel creation tasks explicitly in `stop()` before waiting
- Add `CancelledError` handling in `_create_and_add_to_pool()` and `_create_and_add_to_pool_reserved()`

### Tests Added
- `tests/test_pool_basic_integration.py` - Verifies pre-warming, pool hits, replenishment, graceful shutdown
- `tests/rigorous_pool_test/` - Comprehensive 4-hour stress test suite with watchdog monitoring
- `tests/test_connection_stability.py` - Connection stability tests

## Test plan

- [x] Run `uv run python tests/test_pool_basic_integration.py` - all 8 steps pass
- [x] Verify 100% pool hit rate (no cold starts after warm-up)
- [x] Verify graceful shutdown completes without TimeoutError

🤖 Generated with [Claude Code](https://claude.com/claude-code)