### PR TITLE
docs: incremental snapshot design

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -129,6 +129,61 @@ sandbox = Sandbox.get_from_id(app_id, component="your-component")
 sandbox = Sandbox.create(image="python", component_type="worker")
 ```
 
+## Snapshots
+
+### Full Snapshots
+```python
+sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+sandbox.exec("pip install flask")
+
+# Create full snapshot (captures entire workspace)
+meta = sandbox.create_snapshot(description="After installing deps")
+
+# Restore to another sandbox
+new_sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+new_sandbox.restore_snapshot(meta.snapshot_id)
+```
+
+### Incremental Snapshots
+Capture only files changed since the last snapshot. Reduces upload size by ~95%.
+```python
+# 1. Full base snapshot
+base = sandbox.create_snapshot(description="Base with deps")
+
+# 2. Edit files, then take incremental (only changed files uploaded)
+sandbox.exec("echo 'v2' > /home/sandbox/app/version.txt")
+incr1 = sandbox.create_incremental_snapshot(
+    parent_snapshot_id=base.snapshot_id,
+    description="Version bump",
+)
+# incr1.size_bytes is ~50 bytes vs base's ~250MB
+
+# 3. More edits + deletions → another incremental
+sandbox.exec("rm /home/sandbox/app/old_file.py")
+sandbox.exec("echo 'new' > /home/sandbox/app/new_file.py")
+incr2 = sandbox.create_incremental_snapshot(
+    parent_snapshot_id=incr1.snapshot_id,
+    description="Cleanup + new file",
+)
+
+# 4. Restore full chain to a new sandbox (base → incr1 → incr2)
+new_sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+new_sandbox.restore_snapshot_chain(incr2.snapshot_id)
+# All edits applied, deletions processed, full state restored
+```
+
+**Key behaviors:**
+- `create_incremental_snapshot()` uses `find -newer` marker files for change detection
+- Manifest comparison tracks file deletions between snapshots
+- Falls back to full snapshot if container was recycled (marker file lost)
+- `restore_snapshot_chain()` resolves the chain automatically and applies layers in order
+
+### Hibernate/Wake
+```python
+hibernated = sandbox.hibernate()  # snapshot + delete (~$0.02/mo storage)
+sandbox = Sandbox.wake(hibernated, spaces_config=spaces_config)  # create + restore
+```
+
 ## Large File Transfers
 Files >= 5MB use DO Spaces as intermediary:
 ```python
@@ -183,6 +238,7 @@ Key types exported from `do_app_sandbox`:
 - `SpacesConfig` - Spaces configuration dict
 - `PoolConfig` - Pool configuration for SandboxManager
 - `PoolMetrics` - Pool metrics (ready, in_use, etc.)
+- `SnapshotMetadata` - Snapshot info (snapshot_id, snapshot_type, chain_depth, parent_snapshot_id, etc.)
 
 ## Exceptions
 ```python
@@ -202,6 +258,7 @@ from do_app_sandbox import (
     PoolExhaustedError,     # No sandboxes available
     PoolShutdownError,      # Pool is shutting down
     WarmUpTimeoutError,     # Warm-up timed out
+    SnapshotChainError,     # Broken/cyclic snapshot chain
 )
 ```
 

--- a/docs/design_incremental_snapshots.md
+++ b/docs/design_incremental_snapshots.md
@@ -1,0 +1,1092 @@
+# Incremental Snapshot Design Document
+
+## Status: Draft
+## Author: Design Discussion
+## Date: 2026-04-14
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+The current snapshot system creates a **full `tar.gz` archive** of the entire workspace on every `create_snapshot()` call. This has three consequences:
+
+1. **Redundant uploads**: A Python project with `.venv` is 200-400MB. A Node project with `node_modules` is similar. Editing 3 files and snapshotting re-uploads the entire 400MB.
+2. **No dependency deduplication**: `node_modules` and `.venv` are included in every snapshot. Ten snapshots of the same project with identical dependencies = 10x the storage cost.
+3. **Flat snapshot model**: Snapshots have no ancestry. There is no way to restore from a base + deltas, fork from a point in history, or compact a series of checkpoints.
+
+### Proposed Solution
+
+Extend `SnapshotManager` with three capabilities:
+
+1. **Incremental snapshots** that capture only filesystem changes since the last snapshot
+2. **Content-addressed dependency layers** that are stored once per unique lockfile hash and shared across snapshots
+3. **Snapshot chains** with ancestry tracking, chain resolution, and compaction
+
+### Constraints
+
+- Sandboxes run in App Platform containers — **no overlayfs control, no rsync**
+- All operations go through `sandbox.exec()` (shell commands inside the container)
+- Available tools: `bash`, `tar`, `find`, `stat`, `curl`, `git`, `jq`, `gzip`, `python3`
+- File transfers use presigned DO Spaces URLs (no credentials inside sandbox)
+
+### Not In Scope
+
+- Automatic snapshot triggers (when to snapshot) — this is an orchestration concern, not an SDK concern
+- REST API endpoints for resume/fork — this is a service layer concern
+- Retention policies, GC, billing — product/business logic
+- Multi-tenant cache sharing — no shared tenancy in current architecture
+
+---
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+1. **Incremental snapshots** — capture only files changed since the last snapshot, reducing upload size by ~95% for typical edit-snapshot cycles
+2. **Dependency layer separation** — store `node_modules`/`.venv` once per unique lockfile, content-addressed by lockfile hash
+3. **Snapshot chains** — track parent-child relationships, restore by applying layers in sequence
+4. **Chain compaction** — merge a chain of incrementals into a single full snapshot when chain depth grows
+5. **Change detection** — expose primitives that let consumers know whether a snapshot is worth taking
+6. **Deletion tracking** — correctly handle files deleted between snapshots so they don't reappear on restore
+7. **Backward compatibility** — existing `create_snapshot()` and `restore_snapshot()` unchanged
+
+### Non-Goals
+
+1. **Automatic snapshot triggers** — the SDK provides primitives; consumers (agent frameworks, CI) decide when to call them
+2. **rsync/restic-style chunking** — not available in the container; we use `find -newer` + `tar -T` instead
+3. **Overlay filesystem** — can't control the container's FS driver; we simulate layer semantics in userspace
+4. **Cross-tenant dedup** — no shared tenancy model in the current architecture
+5. **Snapshot streaming/replication** — v1 stores in a single Spaces bucket
+
+---
+
+## 3. Design
+
+### 3.1 Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        SnapshotManager                              │
+│                                                                     │
+│  Existing (unchanged):                                              │
+│  ┌────────────────────────────────────────────────────────────────┐ │
+│  │  create_snapshot()     → full tar.gz, upload to Spaces        │ │
+│  │  restore_snapshot()    → curl | tar streaming restore         │ │
+│  │  list/get/delete/copy  → metadata operations                  │ │
+│  └────────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+│  New:                                                               │
+│  ┌────────────────────────────────────────────────────────────────┐ │
+│  │  create_incremental_snapshot()                                │ │
+│  │    → find -newer marker → tar only changed files              │ │
+│  │    → store manifest.txt + deletions.txt                       │ │
+│  │    → link to parent via parent_snapshot_id                    │ │
+│  │                                                               │ │
+│  │  restore_snapshot_chain()                                     │ │
+│  │    → resolve chain → apply base + incrementals in order       │ │
+│  │    → process deletions at each layer                          │ │
+│  │    → restore dep layer if referenced                          │ │
+│  │                                                               │ │
+│  │  create_dep_layer() / restore_dep_layer()                     │ │
+│  │    → hash lockfile → content-addressed storage                │ │
+│  │    → dedup across snapshots                                   │ │
+│  │                                                               │ │
+│  │  compact_chain()                                              │ │
+│  │    → restore full chain → re-tar as single full snapshot      │ │
+│  │                                                               │ │
+│  │  smart_snapshot()                                             │ │
+│  │    → auto-detect: full vs incremental, separate deps          │ │
+│  │    → auto-compact at chain depth threshold                    │ │
+│  │                                                               │ │
+│  │  resolve_chain()                                              │ │
+│  │    → walk parent links → return ordered [root, ..., tip]      │ │
+│  └────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                    ┌─────────┴─────────┐
+                    ▼                   ▼
+            ┌──────────────┐   ┌───────────────┐
+            │   Snapshots  │   │  Dep Layers   │
+            │  (Spaces)    │   │  (Spaces)     │
+            │              │   │               │
+            │  snapshots/  │   │  deplayers/   │
+            │  ├─ snap-a/  │   │  ├─ sha256-x/ │
+            │  ├─ snap-b/  │   │  ├─ sha256-y/ │
+            │  └─ ...      │   │  └─ ...       │
+            └──────────────┘   └───────────────┘
+```
+
+### 3.2 Snapshot Lifecycle
+
+```
+                          create_snapshot() [existing]
+                                  │
+                                  ▼
+                         ┌────────────────┐
+                         │  Full Snapshot  │  (snap-aaa)
+                         │  archive.tar.gz│  ← full workspace tar
+                         │  manifest.txt  │  ← NEW: file list
+                         │  metadata.json │  ← NEW: snapshot_type="full"
+                         └───────┬────────┘
+                                 │
+                    ··· user edits 3 files ···
+                                 │
+               create_incremental_snapshot(parent="snap-aaa")
+                                 │
+                                 ▼
+                         ┌────────────────┐
+                         │  Incremental   │  (snap-bbb)
+                         │  archive.tar.gz│  ← only 3 changed files
+                         │  manifest.txt  │  ← current file list
+                         │  deletions.txt │  ← files removed since parent
+                         │  metadata.json │  ← parent_snapshot_id="snap-aaa"
+                         └───────┬────────┘
+                                 │
+                    ··· user deletes a file, edits 2 ···
+                                 │
+               create_incremental_snapshot(parent="snap-bbb")
+                                 │
+                                 ▼
+                         ┌────────────────┐
+                         │  Incremental   │  (snap-ccc)
+                         │  archive.tar.gz│  ← 2 changed files
+                         │  deletions.txt │  ← 1 deleted file
+                         │  metadata.json │  ← parent_snapshot_id="snap-bbb"
+                         └────────────────┘
+
+      Restore chain for snap-ccc:
+      ┌──────────┐     ┌──────────┐     ┌──────────┐
+      │ snap-aaa │ ──► │ snap-bbb │ ──► │ snap-ccc │
+      │  (full)  │     │  (incr)  │     │  (incr)  │
+      └──────────┘     └──────────┘     └──────────┘
+        extract          extract          extract
+        full tar         3 files          2 files
+                         (overwrite)      (overwrite)
+                                          rm 1 file
+```
+
+### 3.3 Dependency Layer Architecture
+
+```
+                    ┌────────────────────────────────────┐
+                    │           Sandbox                   │
+                    │                                    │
+                    │  /workspace/                       │
+                    │  ├── app.py          ──┐           │
+                    │  ├── utils.py          │ Workspace │
+                    │  ├── requirements.txt  │ snapshot  │
+                    │  ├── .venv/          ──┘           │
+                    │  │   └── (200MB)     ── Dep layer  │
+                    │  └── data/                         │
+                    └────────────────────────────────────┘
+
+    Snapshot without dep separation:         With dep separation:
+    ┌──────────────────────────┐            ┌──────────────────────────┐
+    │ snap-xxx/archive.tar.gz  │            │ snap-xxx/archive.tar.gz  │
+    │         202 MB           │            │         2 MB             │
+    │ (app + deps together)    │            │ (app code only)          │
+    └──────────────────────────┘            └──────────────────────────┘
+                                            ┌──────────────────────────┐
+                                            │ deplayer-sha256-f7a2/    │
+                                            │   layer.tar.gz  200 MB   │
+                                            │   (shared across snaps)  │
+                                            └──────────────────────────┘
+
+    10 snapshots, same deps:                10 snapshots, same deps:
+    Total: 10 × 202 MB = 2,020 MB          Total: 10 × 2 MB + 200 MB = 220 MB
+                                            Savings: ~89%
+```
+
+### 3.4 Change Detection Mechanism
+
+Since overlayfs and rsync are unavailable, change detection uses `find -newer` with a marker file.
+
+**After each snapshot**, the SDK touches a marker file inside the container:
+
+```bash
+touch /tmp/.snapshot_marker_{snapshot_id}
+```
+
+**Before the next incremental snapshot**, the SDK finds files modified since the marker:
+
+```bash
+find /workspace -newer /tmp/.snapshot_marker_{parent_id} \
+  -not -path '*/node_modules/*' \
+  -not -path '*/.venv/*' \
+  -not -path '*/__pycache__/*' \
+  -not -name '*.pyc' \
+  -type f > /tmp/changed_files.txt 2>/dev/null
+```
+
+**Deletion detection** uses manifest comparison:
+
+```bash
+# Current state
+find /workspace -not -path '*/node_modules/*' -not -path '*/.venv/*' \
+  -type f -printf '%P\n' | sort > /tmp/manifest_current.txt
+
+# Compare against parent manifest
+curl -sSfL '{parent_manifest_url}' | sort > /tmp/manifest_parent.txt
+comm -23 /tmp/manifest_parent.txt /tmp/manifest_current.txt > /tmp/deletions.txt
+```
+
+**Incremental tar** uses the file list:
+
+```bash
+tar -czf /tmp/snapshot_{id}.tar.gz -C / -T /tmp/changed_files.txt
+```
+
+**Fallback**: If the marker file is missing (container was recycled), `create_incremental_snapshot()` automatically falls back to a full snapshot and logs a warning.
+
+---
+
+## 4. Storage Layout
+
+### 4.1 Current Layout (Unchanged)
+
+```
+snapshots/
+├── snap-abc123def456/
+│   ├── metadata.json              # SnapshotMetadata as JSON
+│   └── archive.tar.gz             # Full workspace tar
+```
+
+### 4.2 Extended Layout
+
+```
+snapshots/
+├── snap-abc123/                   # Full snapshot
+│   ├── metadata.json              # snapshot_type: "full"
+│   ├── archive.tar.gz             # Full workspace archive
+│   └── manifest.txt               # Sorted file list (relative paths)
+│
+├── snap-def456/                   # Incremental snapshot
+│   ├── metadata.json              # snapshot_type: "incremental"
+│   │                              # parent_snapshot_id: "snap-abc123"
+│   ├── archive.tar.gz             # Only changed files since parent
+│   ├── manifest.txt               # Current full file list
+│   └── deletions.txt              # Files removed since parent
+│
+├── hibernate-app123-1704672000/   # Hibernation snapshot (existing)
+│   ├── metadata.json
+│   └── archive.tar.gz
+
+deplayers/                         # Content-addressed dependency layers
+├── deplayer-sha256-a1b2c3d4/
+│   ├── metadata.json              # DepLayerMetadata
+│   └── layer.tar.gz               # node_modules or .venv archive
+│
+├── deplayer-sha256-e5f6a7b8/
+│   ├── metadata.json
+│   └── layer.tar.gz
+```
+
+Key design decisions:
+- `manifest.txt` stored with **every** snapshot (full and incremental) so deletion detection works without downloading/extracting the parent archive
+- `deletions.txt` only present in incremental snapshots
+- Dependency layers stored under separate `deplayers/` prefix, content-addressed by lockfile SHA-256
+- Existing full snapshots continue to work — new files are additive
+
+---
+
+## 5. Data Model
+
+### 5.1 SnapshotMetadata (Extended)
+
+**File: `src/do_app_sandbox/types.py`**
+
+New fields added to existing `SnapshotMetadata` dataclass. All have defaults for backward compatibility.
+
+```python
+@dataclass
+class SnapshotMetadata:
+    """Metadata about a saved snapshot."""
+
+    # --- Existing fields (unchanged) ---
+    snapshot_id: str
+    created_at: float
+    sandbox_image: str
+    size_bytes: int
+    paths: list[str]
+    description: str | None = None
+    tags: dict[str, str] = field(default_factory=dict)
+
+    # --- New fields for incremental snapshots ---
+    snapshot_type: str = "full"              # "full" | "incremental"
+    parent_snapshot_id: str | None = None    # ID of parent (None for full snapshots)
+    chain_depth: int = 0                     # 0 for full, N for Nth incremental in chain
+    chain_root_id: str | None = None         # ID of the chain's root full snapshot
+    files_changed: int = 0                   # Count of files in this layer's archive
+    files_deleted: int = 0                   # Count of files in deletions.txt
+    dep_layer_id: str | None = None          # Associated content-addressed dep layer
+    lockfile_hash: str | None = None         # SHA-256 of lockfile (for dep layer lookup)
+```
+
+**Backward compatibility**: `SnapshotMetadata(**old_json)` works because all new fields have defaults. Existing snapshots implicitly have `snapshot_type="full"`, `parent_snapshot_id=None`, `chain_depth=0`.
+
+### 5.2 DepLayerMetadata (New)
+
+```python
+@dataclass
+class DepLayerMetadata:
+    """Metadata about a content-addressed dependency layer."""
+
+    layer_id: str                            # "deplayer-sha256-{hash[:16]}"
+    created_at: float
+    lockfile_hash: str                       # Full SHA-256 of lockfile contents
+    lockfile_name: str                       # e.g. "package-lock.json", "requirements.txt"
+    dep_path: str                            # e.g. "/workspace/node_modules", "/workspace/.venv"
+    size_bytes: int
+    sandbox_image: str                       # Image this layer was built for
+    reference_count: int = 0                 # Snapshots referencing this layer
+```
+
+### 5.3 New Exceptions
+
+**File: `src/do_app_sandbox/exceptions.py`**
+
+```python
+class SnapshotChainError(SnapshotError):
+    """Raised when snapshot chain is broken, cyclic, or invalid."""
+    pass
+
+class DepLayerError(SnapshotError):
+    """Raised when dependency layer creation or restoration fails."""
+    pass
+```
+
+---
+
+## 6. API Design
+
+### 6.1 SnapshotManager Methods (New)
+
+All methods are added to `SnapshotManager` in `src/do_app_sandbox/snapshot.py`. Existing methods are unchanged.
+
+#### `create_incremental_snapshot()`
+
+Creates a snapshot containing only files changed since the parent snapshot.
+
+```python
+def create_incremental_snapshot(
+    self,
+    sandbox: "Sandbox",
+    parent_snapshot_id: str,
+    snapshot_id: str | None = None,
+    paths: list[str] | None = None,
+    exclude_deps: bool = True,
+    description: str | None = None,
+    tags: dict[str, str] | None = None,
+    timeout: int = 600,
+) -> SnapshotMetadata:
+```
+
+**Behavior**:
+1. Validate parent exists via `get_snapshot(parent_snapshot_id)`
+2. Check marker file `/tmp/.snapshot_marker_{parent_snapshot_id}`
+   - Missing → fall back to `create_snapshot()` (full), log warning
+3. Run `find -newer` to build changed files list (excluding deps if `exclude_deps=True`)
+4. Download parent's `manifest.txt`, generate current `manifest.txt`, compute `deletions.txt`
+5. If no changes and no deletions → return metadata with `size_bytes=0` (no archive uploaded)
+6. Create tar from changed file list only, upload archive + manifest + deletions
+7. Touch new marker file
+
+**Returns**: `SnapshotMetadata` with `snapshot_type="incremental"`, `parent_snapshot_id` set, `chain_depth = parent.chain_depth + 1`
+
+#### `restore_snapshot_chain()`
+
+Restores a snapshot by applying its entire chain (root full + all incrementals).
+
+```python
+def restore_snapshot_chain(
+    self,
+    sandbox: "Sandbox",
+    snapshot_id: str,
+    target_path: str = "/",
+    timeout: int = 600,
+) -> bool:
+```
+
+**Behavior**:
+1. Call `resolve_chain(snapshot_id)` to get ordered list `[root_full, incr_1, ..., target]`
+2. For each snapshot in chain:
+   a. If `size_bytes > 0`: stream-extract archive via `curl | tar`
+   b. If incremental and `files_deleted > 0`: download `deletions.txt`, batch-delete via `xargs rm -f`
+3. If final snapshot has `dep_layer_id`: call `restore_dep_layer()`
+4. Touch marker file for the most recent snapshot
+
+#### `resolve_chain()`
+
+Walks parent links to build the ordered snapshot chain.
+
+```python
+def resolve_chain(self, snapshot_id: str) -> list[SnapshotMetadata]:
+```
+
+**Behavior**:
+1. Start at `snapshot_id`, follow `parent_snapshot_id` links until `snapshot_type == "full"` or `parent_snapshot_id is None`
+2. Detect cycles via visited set
+3. Return list ordered `[root_full, incr_1, ..., target]`
+
+**Raises**: `SnapshotChainError` if chain is broken (missing parent), cyclic, or doesn't terminate at a full snapshot
+
+#### `create_dep_layer()`
+
+Creates a content-addressed dependency layer from a lockfile and its dep directory.
+
+```python
+def create_dep_layer(
+    self,
+    sandbox: "Sandbox",
+    lockfile_path: str,
+    dep_path: str,
+    timeout: int = 600,
+) -> DepLayerMetadata:
+```
+
+**Behavior**:
+1. Read lockfile via `sandbox.exec(f"cat {lockfile_path}")`
+2. Compute SHA-256 on SDK host (Python `hashlib`)
+3. Check if `deplayers/deplayer-sha256-{hash[:16]}/metadata.json` exists in Spaces
+   - If yes → return existing `DepLayerMetadata` (dedup hit, no upload)
+4. Create tar of dep directory: `tar -czf /tmp/deplayer.tar.gz -C / {dep_path}`
+5. Upload to `deplayers/deplayer-sha256-{hash[:16]}/layer.tar.gz`
+6. Save metadata
+
+#### `restore_dep_layer()`
+
+Restores a dependency layer to the sandbox.
+
+```python
+def restore_dep_layer(
+    self,
+    sandbox: "Sandbox",
+    layer_id: str,
+    target_path: str = "/",
+    timeout: int = 600,
+) -> bool:
+```
+
+**Behavior**: Generate presigned URL, `curl | tar` extraction. Same pattern as `restore_snapshot()`.
+
+#### `compact_chain()`
+
+Merges a snapshot chain into a single full snapshot.
+
+```python
+def compact_chain(
+    self,
+    sandbox: "Sandbox",
+    snapshot_id: str,
+    new_snapshot_id: str | None = None,
+    delete_old: bool = False,
+    timeout: int = 600,
+) -> SnapshotMetadata:
+```
+
+**Behavior**:
+1. `restore_snapshot_chain()` to apply full chain to the sandbox
+2. `create_snapshot()` to tar the resulting state as a new full snapshot
+3. If `delete_old=True`: delete old chain members (but never delete dep layers — they may be shared)
+4. Return new `SnapshotMetadata` with `chain_depth=0`, `parent_snapshot_id=None`
+
+**Note**: Compaction requires a live sandbox because we can't merge tar layers without extracting them first (no rsync/overlayfs).
+
+#### `smart_snapshot()`
+
+High-level convenience method that auto-selects the optimal snapshot strategy.
+
+```python
+def smart_snapshot(
+    self,
+    sandbox: "Sandbox",
+    snapshot_id: str | None = None,
+    paths: list[str] | None = None,
+    description: str | None = None,
+    tags: dict[str, str] | None = None,
+    max_chain_depth: int = 10,
+    auto_compact: bool = True,
+    separate_deps: bool = True,
+    timeout: int = 600,
+) -> SnapshotMetadata:
+```
+
+**Behavior**:
+1. Look for existing marker files to detect a valid parent
+   - No marker → create full snapshot
+   - Marker found → create incremental snapshot
+2. If `separate_deps=True`: scan for lockfiles, create/reuse dep layers
+3. If resulting `chain_depth >= max_chain_depth` and `auto_compact=True`: trigger compaction
+4. Return the snapshot metadata
+
+### 6.2 Sandbox Wrapper Methods (New)
+
+**File: `src/do_app_sandbox/sandbox.py`**
+
+Thin wrappers added alongside existing `create_snapshot()` and `restore_snapshot()`:
+
+```python
+def create_incremental_snapshot(
+    self,
+    parent_snapshot_id: str,
+    **kwargs,
+) -> SnapshotMetadata:
+    """Create an incremental snapshot relative to a parent.
+
+    Only captures files changed since the parent snapshot.
+    Falls back to full snapshot if the container was recycled.
+    """
+    self._ensure_awake()
+    snapshot_mgr = SnapshotManager(self._spaces_config)
+    return snapshot_mgr.create_incremental_snapshot(
+        sandbox=self, parent_snapshot_id=parent_snapshot_id, **kwargs
+    )
+
+def restore_snapshot_chain(
+    self,
+    snapshot_id: str,
+    target_path: str = "/",
+    timeout: int = 600,
+) -> bool:
+    """Restore a snapshot by applying its full chain.
+
+    Resolves the chain from root full snapshot through all
+    incremental layers, applying them in order.
+    """
+    self._ensure_awake()
+    snapshot_mgr = SnapshotManager(self._spaces_config)
+    return snapshot_mgr.restore_snapshot_chain(
+        sandbox=self, snapshot_id=snapshot_id,
+        target_path=target_path, timeout=timeout,
+    )
+
+def smart_snapshot(self, **kwargs) -> SnapshotMetadata:
+    """Create the optimal snapshot automatically.
+
+    Auto-detects whether to create a full or incremental snapshot,
+    optionally separates dependency layers, and auto-compacts
+    when chains get too long.
+    """
+    self._ensure_awake()
+    snapshot_mgr = SnapshotManager(self._spaces_config)
+    return snapshot_mgr.smart_snapshot(sandbox=self, **kwargs)
+```
+
+### 6.3 Lockfile Detection
+
+Known lockfiles and their associated dependency paths:
+
+| Lockfile | Dep Path | Image |
+|----------|----------|-------|
+| `package-lock.json` | `node_modules` | node |
+| `yarn.lock` | `node_modules` | node |
+| `pnpm-lock.yaml` | `node_modules` | node |
+| `bun.lockb` | `node_modules` | node |
+| `requirements.txt` | `.venv` | python |
+| `Pipfile.lock` | `.venv` | python |
+| `poetry.lock` | `.venv` | python |
+| `uv.lock` | `.venv` | python |
+
+Detection scans the workspace root for these files. If multiple exist, the first match (in the order above) is used. The mapping is defined as a constant, not hardcoded in logic.
+
+---
+
+## 7. Algorithms
+
+### 7.1 Chain Resolution
+
+```
+resolve_chain("snap-ccc"):
+
+  visited = {}
+  chain = []
+
+  current = "snap-ccc"
+    → meta = get_snapshot("snap-ccc")
+    → snapshot_type = "incremental", parent = "snap-bbb"
+    → chain = [snap-ccc]
+    → visited = {snap-ccc}
+
+  current = "snap-bbb"
+    → meta = get_snapshot("snap-bbb")
+    → snapshot_type = "incremental", parent = "snap-aaa"
+    → chain = [snap-ccc, snap-bbb]
+    → visited = {snap-ccc, snap-bbb}
+
+  current = "snap-aaa"
+    → meta = get_snapshot("snap-aaa")
+    → snapshot_type = "full"
+    → chain = [snap-ccc, snap-bbb, snap-aaa]
+    → STOP (reached full snapshot)
+
+  reverse → [snap-aaa, snap-bbb, snap-ccc]
+```
+
+Error conditions:
+- `get_snapshot()` returns None → `SnapshotChainError("Broken chain: snap-xxx not found")`
+- `current_id in visited` → `SnapshotChainError("Cycle detected at snap-xxx")`
+- Chain ends without reaching a full snapshot → `SnapshotChainError("Chain does not terminate at a full snapshot")`
+
+### 7.2 Incremental Restore
+
+```
+restore_snapshot_chain("snap-ccc"):
+
+  chain = resolve_chain("snap-ccc")
+  → [snap-aaa (full), snap-bbb (incr), snap-ccc (incr)]
+
+  Step 1: Apply snap-aaa (full)
+    curl -sSfL '{url}' | tar -xzf - -C /
+    → Extracts complete workspace
+
+  Step 2: Apply snap-bbb (incremental)
+    curl -sSfL '{url}' | tar -xzf - -C /
+    → Overwrites 3 changed files in-place
+    (deletions.txt empty for this layer)
+
+  Step 3: Apply snap-ccc (incremental)
+    curl -sSfL '{url}' | tar -xzf - -C /
+    → Overwrites 2 changed files in-place
+    curl -sSfL '{deletions_url}' | xargs -d '\n' -I{} rm -f '/workspace/{}'
+    → Removes 1 deleted file
+
+  Step 4: Restore dep layer (if snap-ccc.dep_layer_id is set)
+    curl -sSfL '{dep_url}' | tar -xzf - -C /
+    → Extracts node_modules or .venv
+
+  Step 5: Touch marker
+    touch /tmp/.snapshot_marker_snap-ccc
+```
+
+### 7.3 Content-Addressed Dedup
+
+```
+create_dep_layer(lockfile="/workspace/package-lock.json", dep="/workspace/node_modules"):
+
+  Step 1: Read lockfile content
+    sandbox.exec("cat /workspace/package-lock.json")
+    → lockfile_content = "{ ... }"
+
+  Step 2: Hash
+    hashlib.sha256(lockfile_content.encode()).hexdigest()
+    → "f7a2b3c4d5e6..."
+
+  Step 3: Check Spaces
+    key = "deplayers/deplayer-sha256-f7a2b3c4d5e6/metadata.json"
+    exists? → Yes → return existing DepLayerMetadata (no upload!)
+
+  Step 3 (alt): Not in Spaces
+    tar -czf /tmp/deplayer.tar.gz -C / workspace/node_modules
+    upload to deplayers/deplayer-sha256-f7a2b3c4d5e6/layer.tar.gz
+    save metadata
+    return new DepLayerMetadata
+```
+
+Two snapshots with identical `package-lock.json` → same dep layer ID → zero additional storage.
+
+---
+
+## 8. Size Impact Analysis
+
+### Typical Python Project
+
+| Component | Size |
+|-----------|------|
+| Application code | ~2 MB |
+| `.venv` | ~250 MB |
+| Data/output files | ~10 MB |
+| **Total workspace** | **~262 MB** |
+
+| Operation | Full Snapshot | Incremental + Dep Layer |
+|-----------|--------------|------------------------|
+| First snapshot | 262 MB | 2 MB (code) + 250 MB (dep layer) = 252 MB |
+| Edit 3 files, snapshot | 262 MB | ~50 KB (3 files only) |
+| Edit 5 files, snapshot | 262 MB | ~100 KB |
+| 10 snapshots, same deps | **2,620 MB** | 252 MB + 9 × ~75 KB = **~253 MB** |
+| **Storage savings** | — | **~90%** |
+
+### Typical Node Project
+
+| Component | Size |
+|-----------|------|
+| Application code | ~5 MB |
+| `node_modules` | ~400 MB |
+| Build output | ~20 MB |
+| **Total workspace** | **~425 MB** |
+
+| Operation | Full Snapshot | Incremental + Dep Layer |
+|-----------|--------------|------------------------|
+| First snapshot | 425 MB | 5 MB + 400 MB = 405 MB |
+| Edit 3 files, snapshot | 425 MB | ~80 KB |
+| 10 snapshots, same deps | **4,250 MB** | 405 MB + 9 × ~80 KB ≈ **~406 MB** |
+| **Storage savings** | — | **~90%** |
+
+### Bandwidth Impact
+
+Incremental snapshot creation requires uploading only the changed files. For a typical edit-snapshot cycle (3-5 files changed):
+
+| Metric | Full Snapshot | Incremental |
+|--------|--------------|-------------|
+| Upload size | 250-425 MB | 50-100 KB |
+| Upload time (10 Mbps) | 200-340s | <1s |
+| Spaces egress on restore (full chain of 5) | 250-425 MB | 250 MB (base) + ~400 KB (deltas) |
+
+The restore cost is dominated by the base snapshot. Incremental layers add negligible bandwidth.
+
+---
+
+## 9. Edge Cases and Failure Modes
+
+### 9.1 Marker File Lost
+
+**Scenario**: Container restarts between snapshots. `/tmp/.snapshot_marker_{parent_id}` no longer exists.
+
+**Behavior**: `create_incremental_snapshot()` detects the missing marker and falls back to a full snapshot. The returned metadata has `snapshot_type="full"`. A warning is logged.
+
+**Why**: `find -newer` against a nonexistent file would produce unpredictable results. A full snapshot is always safe.
+
+### 9.2 Clock Skew
+
+**Scenario**: Container's system clock drifts. `find -newer` relies on mtime comparisons.
+
+**Mitigation**: After touching the marker, store the epoch timestamp in snapshot metadata (`created_at`). On the next incremental, verify the marker file's mtime matches `created_at` within a tolerance (e.g., 60 seconds). If not, fall back to full.
+
+### 9.3 /tmp Cleanup
+
+**Scenario**: Container runtime cleans `/tmp` periodically (e.g., `tmpwatch`, `tmpreaper`).
+
+**Mitigation**: Use dot-prefixed filenames (`.snapshot_marker_*`) which most cleanup tools skip. The marker file is <1 byte; no disk pressure concern.
+
+### 9.4 Broken Chain
+
+**Scenario**: A snapshot in the middle of a chain is deleted (e.g., user calls `delete_snapshot()` on a parent).
+
+**Behavior**: `resolve_chain()` raises `SnapshotChainError` with a message identifying the missing link. The chain cannot be restored.
+
+**Prevention**: `delete_snapshot()` should check if the snapshot is referenced as a parent by any other snapshot. If so, refuse deletion or require `force=True`.
+
+### 9.5 Large Deletions
+
+**Scenario**: Thousands of files deleted between snapshots. `deletions.txt` is large.
+
+**Mitigation**: Use `xargs -d '\n' rm -f` for batch deletion instead of per-file shell loop. `xargs` handles argument batching automatically.
+
+### 9.6 Direct Dependency Modification
+
+**Scenario**: User patches a file directly inside `node_modules` (e.g., `node_modules/lodash/index.js`).
+
+**Behavior**: If `exclude_deps=True` (default for incremental), the modification is NOT captured. On restore, the unmodified dep layer is applied.
+
+**Documentation**: Make it clear that dep layers are lockfile-keyed. Direct modifications to dep directories should use `exclude_deps=False`.
+
+### 9.7 Empty Incremental
+
+**Scenario**: No files changed and no files deleted since the parent snapshot.
+
+**Behavior**: No archive is created or uploaded. Metadata is stored with `size_bytes=0`, `files_changed=0`, `files_deleted=0`. On restore, this layer is skipped (no `curl | tar` call).
+
+### 9.8 Concurrent Snapshots
+
+**Scenario**: Two `create_incremental_snapshot()` calls with the same parent from different processes.
+
+**Behavior**: Both succeed independently — they produce different snapshot IDs, both with the same parent. This creates a fork in the chain (two children of one parent). `resolve_chain()` handles this correctly because it walks from child to parent, not parent to children.
+
+---
+
+## 10. Modifications to Existing Code
+
+### 10.1 `create_snapshot()` Additions
+
+Two non-breaking additions to the existing `create_snapshot()` method:
+
+1. **Store `manifest.txt`** alongside the archive after upload:
+   ```python
+   # After archive upload, generate and store manifest
+   manifest_cmd = f"find {paths_str_abs} ... -type f -printf '%P\\n' | sort"
+   manifest_result = sandbox.exec(manifest_cmd, timeout=timeout)
+   manifest_key = f"{self._prefix}{snapshot_id}/manifest.txt"
+   self._spaces.put_object(manifest_key, manifest_result.stdout.encode())
+   ```
+
+2. **Touch marker file** after successful snapshot:
+   ```python
+   sandbox.exec(f"touch /tmp/.snapshot_marker_{snapshot_id}")
+   ```
+
+These additions don't change the return type, behavior, or API contract. Existing consumers are unaffected.
+
+### 10.2 `__init__.py` Export Additions
+
+Add to imports and `__all__`:
+- `DepLayerMetadata` from `types`
+- `SnapshotChainError` from `exceptions`
+- `DepLayerError` from `exceptions`
+
+---
+
+## 11. Usage Examples
+
+### 11.1 Basic Incremental Workflow
+
+```python
+from do_app_sandbox import Sandbox
+
+sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+
+# Initial setup
+sandbox.exec("cd /workspace && uv venv .venv && uv pip install flask numpy")
+sandbox.filesystem.upload_file("app.py", "/workspace/app.py")
+
+# First snapshot (full)
+base = sandbox.create_snapshot(description="Initial setup with deps")
+
+# ... user makes changes ...
+sandbox.exec("echo 'print(1)' >> /workspace/app.py")
+sandbox.filesystem.upload_file("utils.py", "/workspace/utils.py")
+
+# Incremental snapshot (only captures app.py change + new utils.py)
+incr = sandbox.create_incremental_snapshot(
+    parent_snapshot_id=base.snapshot_id,
+    description="Added utils module",
+)
+print(f"Full snapshot: {base.size_bytes / 1024 / 1024:.1f}MB")
+print(f"Incremental:  {incr.size_bytes / 1024:.1f}KB")  # ~2KB vs ~250MB
+
+# Restore to a new sandbox
+new_sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+new_sandbox.restore_snapshot_chain(incr.snapshot_id)
+```
+
+### 11.2 Smart Snapshot (Auto-Detect)
+
+```python
+# First call: no marker exists → creates full snapshot + dep layer
+meta1 = sandbox.smart_snapshot(
+    description="After setup",
+    separate_deps=True,
+)
+# snapshot_type="full", dep_layer_id="deplayer-sha256-f7a2..."
+
+# Second call: marker exists → creates incremental
+sandbox.exec("echo 'v2' > /workspace/version.txt")
+meta2 = sandbox.smart_snapshot(description="Version bump")
+# snapshot_type="incremental", size_bytes=~50B
+
+# After 10 increments: auto-compacts back to full
+for i in range(10):
+    sandbox.exec(f"echo '{i}' > /workspace/iter_{i}.txt")
+    meta = sandbox.smart_snapshot(max_chain_depth=10)
+# At chain_depth=10, auto-compaction creates a new full snapshot
+```
+
+### 11.3 Dependency Layer Sharing
+
+```python
+from do_app_sandbox.snapshot import SnapshotManager
+
+mgr = SnapshotManager(spaces_config)
+
+# Sandbox A: install deps, create dep layer
+sandbox_a = Sandbox.create(image="python", spaces_config=spaces_config)
+sandbox_a.exec("cd /workspace && echo 'flask==3.0' > requirements.txt")
+sandbox_a.exec("cd /workspace && uv venv .venv && uv pip install -r requirements.txt")
+
+dep = mgr.create_dep_layer(sandbox_a, "/workspace/requirements.txt", "/workspace/.venv")
+print(f"Dep layer: {dep.layer_id}")  # deplayer-sha256-abc123...
+
+# Sandbox B: same requirements.txt → reuses existing layer (no upload)
+sandbox_b = Sandbox.create(image="python", spaces_config=spaces_config)
+sandbox_b.exec("cd /workspace && echo 'flask==3.0' > requirements.txt")
+
+dep2 = mgr.create_dep_layer(sandbox_b, "/workspace/requirements.txt", "/workspace/.venv")
+assert dep.layer_id == dep2.layer_id  # Same lockfile hash → same layer
+
+# Restore dep layer to a fresh sandbox
+sandbox_c = Sandbox.create(image="python", spaces_config=spaces_config)
+mgr.restore_dep_layer(sandbox_c, dep.layer_id)
+result = sandbox_c.exec("/workspace/.venv/bin/flask --version")
+# flask 3.0 — available without reinstalling
+```
+
+### 11.4 Chain Compaction
+
+```python
+# Build up a chain
+base = sandbox.create_snapshot(description="Base")
+for i in range(12):
+    sandbox.exec(f"echo 'change {i}' > /workspace/file_{i}.txt")
+    sandbox.create_incremental_snapshot(parent_snapshot_id=base.snapshot_id if i == 0 else prev.snapshot_id)
+
+# Chain is now 13 snapshots deep — compact it
+mgr = SnapshotManager(spaces_config)
+compacted = mgr.compact_chain(sandbox, prev.snapshot_id, delete_old=True)
+print(f"Compacted: chain_depth={compacted.chain_depth}")  # 0 (single full snapshot)
+```
+
+### 11.5 Pool + Incremental Restore
+
+```python
+from do_app_sandbox import SandboxManager, PoolConfig
+
+manager = SandboxManager(
+    pools={"python": PoolConfig(target_ready=3)},
+    sandbox_defaults={"spaces_config": spaces_config},
+)
+await manager.start()
+
+# Acquire from pool + restore incremental chain
+# Pool acquisition: ~0ms (warm) + chain restore: ~3s (base) + ~50ms (deltas)
+sandbox = await manager.acquire_with_snapshot("python", incr.snapshot_id)
+```
+
+---
+
+## 12. Implementation Phases
+
+### Phase 1: Foundation
+
+**Scope**: Metadata schema, chain resolution, manifest generation, marker files
+
+**Changes**:
+- `types.py`: Add new fields to `SnapshotMetadata`, add `DepLayerMetadata`
+- `exceptions.py`: Add `SnapshotChainError`, `DepLayerError`
+- `snapshot.py`: Add `resolve_chain()`, modify `create_snapshot()` to store `manifest.txt` and touch marker
+- `__init__.py`: Export new types and exceptions
+
+**Tests**:
+- Unit: metadata backward compat, `resolve_chain()` with mocked data, cycle detection, broken chain
+- Integration: verify `manifest.txt` stored alongside existing snapshot, marker file created
+
+**What it enables**: Chain-aware metadata model. No new user-facing snapshot API yet, but the foundation is in place.
+
+### Phase 2: Incremental Snapshots
+
+**Scope**: `create_incremental_snapshot()`, `restore_snapshot_chain()`
+
+**Changes**:
+- `snapshot.py`: Add both methods
+- `sandbox.py`: Add wrapper methods on `Sandbox`
+
+**Tests**:
+- Unit: mock `sandbox.exec()` → verify exact `find -newer`, `tar -T`, `comm -23` commands
+- Integration: full → edit → incremental → restore chain → verify file contents
+- Size test: incremental archive must be <1% of full archive size for 1-file edit
+
+**What it enables**: Delta-only snapshots. The primary cost and bandwidth optimization.
+
+### Phase 3: Dependency Layers
+
+**Scope**: `create_dep_layer()`, `restore_dep_layer()`, lockfile detection
+
+**Changes**:
+- `snapshot.py`: Add both methods plus lockfile detection constant/logic
+
+**Tests**:
+- Unit: content-addressing logic, lockfile hash computation
+- Integration: create dep layer → change lockfile → verify new layer ID; same lockfile → verify dedup (no upload)
+
+**What it enables**: Shared dependency storage. The second major cost optimization.
+
+### Phase 4: Smart Snapshot + Compaction
+
+**Scope**: `smart_snapshot()`, `compact_chain()`
+
+**Changes**:
+- `snapshot.py`: Add both methods
+- `sandbox.py`: Add `smart_snapshot()` wrapper
+
+**Tests**:
+- Integration: create chain of N → compact → verify single full snapshot with correct contents
+- Integration: `smart_snapshot()` auto-selects full vs incremental correctly
+
+**What it enables**: One-call optimal snapshots. Chain housekeeping.
+
+### Phase 5: Manager Integration
+
+**Scope**: Pool-aware incremental restore
+
+**Changes**:
+- `manager.py`: Update `acquire_with_snapshot()` to detect chain and use `restore_snapshot_chain()` when metadata indicates incremental; add `acquire_with_chain()` method
+
+**Tests**:
+- Integration: pool acquire + chain restore end-to-end
+- Benchmark: compare full restore vs chain restore latency
+
+**What it enables**: Warm pool + incremental restore for minimal total startup time.
+
+---
+
+## 13. Testing Strategy
+
+### 13.1 Unit Tests
+
+| Test | Validates |
+|------|-----------|
+| Metadata backward compat | `SnapshotMetadata(**old_json)` works, defaults applied |
+| `resolve_chain()` - happy path | Returns correct ordered chain |
+| `resolve_chain()` - broken chain | Raises `SnapshotChainError` |
+| `resolve_chain()` - cycle | Raises `SnapshotChainError` |
+| `resolve_chain()` - full snapshot | Returns single-element list |
+| Incremental tar commands | Verify `find -newer`, `tar -T` command strings |
+| Manifest comparison commands | Verify `comm -23` command string |
+| Lockfile hash computation | Known input → known SHA-256 |
+| Dep layer content addressing | Same hash → same layer ID |
+| Dep layer path detection | Lockfile name → correct dep path |
+
+### 13.2 Integration Tests
+
+| Test | Validates |
+|------|-----------|
+| Full → incremental → restore chain | Files present and correct |
+| Incremental with deletions | Deleted files absent after restore |
+| Dep layer create + restore | Dependencies available without install |
+| Dep layer dedup | Second create returns same ID, no upload |
+| Chain compaction | Result is single full snapshot with all changes |
+| Smart snapshot auto-detection | No marker → full; marker → incremental |
+| Marker fallback | Remove marker → full snapshot, not error |
+| Empty incremental | No changes → `size_bytes=0`, restore skips layer |
+
+### 13.3 Benchmarks
+
+| Benchmark | Measures |
+|-----------|----------|
+| Incremental vs full snapshot size | Bytes uploaded for 1, 5, 10 file edits |
+| Chain restore latency vs full restore | Time to restore chain of N vs single full |
+| Dep layer dedup hit ratio | Percentage of dep layer creates that skip upload |
+
+---
+
+## 14. Future Considerations
+
+### Not in V1 but worth tracking
+
+1. **`delete_snapshot()` chain safety**: Check if snapshot is a parent before allowing deletion. V1 raises error on broken chain at restore time; future versions could prevent it at delete time.
+
+2. **Automatic chain compaction in background**: SandboxManager could compact chains during idle replenishment loops.
+
+3. **Dep layer garbage collection**: Reference counting in `DepLayerMetadata`. When `reference_count` drops to 0 (no snapshots reference the layer), it's eligible for deletion.
+
+4. **Snapshot trigger hooks**: A callback interface (`on_snapshot`, `should_snapshot`) that consumers register. The SDK calls these at checkpoints; consumers decide whether to proceed. This is how agent frameworks would integrate automatic triggers without coupling agent logic into the SDK.
+
+5. **Change detection helper**: A public `has_workspace_changed(parent_snapshot_id)` method that returns `bool` + changed file count. Lets consumers decide whether a snapshot is worth taking before paying the tar/upload cost.
+
+6. **zstd compression**: Replace `gzip` with `zstd` for faster compression and better ratios. Requires verifying `zstd` availability in containers (or adding it to images).
+
+---
+
+## 15. Related Files
+
+| File | Role |
+|------|------|
+| `src/do_app_sandbox/snapshot.py` | Primary implementation — all new methods here |
+| `src/do_app_sandbox/types.py` | Data model changes |
+| `src/do_app_sandbox/exceptions.py` | New exception classes |
+| `src/do_app_sandbox/sandbox.py` | Wrapper methods on Sandbox class |
+| `src/do_app_sandbox/manager.py` | Pool integration (Phase 5) |
+| `src/do_app_sandbox/spaces.py` | Storage client (unchanged) |
+| `src/do_app_sandbox/__init__.py` | Export additions |
+| `tests/unit/test_snapshot.py` | Unit tests |
+| `tests/integration/test_snapshots.py` | Integration tests |
+| `docs/snapshots_vs_custom_images.md` | User-facing docs (update after implementation) |

--- a/docs/design_incremental_snapshots.md
+++ b/docs/design_incremental_snapshots.md
@@ -1,8 +1,32 @@
 # Incremental Snapshot Design Document
 
-## Status: Draft
+## Status: Implemented (Phase 1-2)
 ## Author: Design Discussion
 ## Date: 2026-04-14
+
+---
+
+## TL;DR — User-Facing API
+
+```python
+sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+
+# Full base snapshot (same as before)
+base = sandbox.create_snapshot(description="Base")
+
+# Edit files, then take incremental (only changed files, ~95% smaller)
+sandbox.exec("echo 'v2' > /home/sandbox/app/version.txt")
+incr = sandbox.create_incremental_snapshot(parent_snapshot_id=base.snapshot_id)
+
+# Restore full chain to a new sandbox (resolves: base → incr automatically)
+new_sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+new_sandbox.restore_snapshot_chain(incr.snapshot_id)
+```
+
+**Users call snapshot methods explicitly.** The SDK does not automatically trigger snapshots — that's an orchestration concern. The three methods are:
+- `create_snapshot()` — full snapshot (unchanged)
+- `create_incremental_snapshot(parent_snapshot_id)` — delta-only snapshot
+- `restore_snapshot_chain(snapshot_id)` — resolve and apply full chain
 
 ---
 

--- a/docs/snapshots_vs_custom_images.md
+++ b/docs/snapshots_vs_custom_images.md
@@ -132,6 +132,57 @@ Do you know your environment ahead of time?
     └── Need to hibernate for cost savings? → Snapshots
 ```
 
+## Incremental Snapshots
+
+For workloads that take frequent checkpoints, incremental snapshots capture only the files changed since the last snapshot — reducing upload size by ~95% and storage by ~90%.
+
+### When to Use
+
+- Agent tasks that checkpoint frequently (every few edits)
+- Iterative development with small changes between snapshots
+- Projects with large dependencies (node_modules, .venv) that don't change often
+
+### How It Works
+
+```python
+sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+sandbox.exec("cd /home/sandbox/app && uv venv .venv && uv pip install flask")
+sandbox.filesystem.upload_file("app.py", "/home/sandbox/app/app.py")
+
+# First snapshot is always full (~250MB with .venv)
+base = sandbox.create_snapshot(description="Base with deps")
+
+# Edit 2 files → incremental captures only those 2 files (~50 bytes)
+sandbox.exec("echo 'v2' > /home/sandbox/app/app.py")
+sandbox.exec("echo 'helpers' > /home/sandbox/app/utils.py")
+incr = sandbox.create_incremental_snapshot(
+    parent_snapshot_id=base.snapshot_id,
+    description="Updated app, added utils",
+)
+
+# Restore full chain to a new sandbox
+new_sandbox = Sandbox.create(image="python", spaces_config=spaces_config)
+new_sandbox.restore_snapshot_chain(incr.snapshot_id)
+# Applies: base (full) → incr (changed files only)
+# Result: complete workspace with all deps + updated files
+```
+
+### Key Details
+
+- **Change detection**: Uses `find -newer` with marker files — no rsync or overlayfs needed
+- **Deletion tracking**: Manifest comparison detects files removed between snapshots
+- **Fallback**: If the container is recycled (marker lost), automatically falls back to full snapshot
+- **Chain resolution**: `restore_snapshot_chain()` walks parent links and applies layers in order
+- **Metadata**: `SnapshotMetadata.snapshot_type` is `"full"` or `"incremental"`, `chain_depth` tracks position
+
+### Size Impact
+
+| Operation | Full Snapshot | Incremental |
+|-----------|--------------|-------------|
+| First snapshot (Python + .venv) | ~250 MB | ~250 MB (always full) |
+| Edit 3 files, snapshot | ~250 MB | ~50 KB |
+| 10 snapshots, same deps | ~2,500 MB | ~250 MB + 9 × ~75 KB |
+
 ## Combining Both
 
 Custom images and snapshots are not mutually exclusive:

--- a/src/do_app_sandbox/__init__.py
+++ b/src/do_app_sandbox/__init__.py
@@ -66,6 +66,7 @@ from .exceptions import (
     ServiceModeError,
     ServiceNotAvailableError,
     # Snapshot exceptions
+    SnapshotChainError,
     SnapshotError,
     SnapshotNotFoundError,
     SnapshotRestoreError,
@@ -176,6 +177,7 @@ __all__ = [
     "SnapshotNotFoundError",
     "SnapshotUploadError",
     "SnapshotRestoreError",
+    "SnapshotChainError",
     # Service mode exceptions
     "ServiceModeError",
     "ServiceNotAvailableError",

--- a/src/do_app_sandbox/exceptions.py
+++ b/src/do_app_sandbox/exceptions.py
@@ -121,6 +121,12 @@ class SnapshotRestoreError(SnapshotError):
     pass
 
 
+class SnapshotChainError(SnapshotError):
+    """Raised when snapshot chain is broken, cyclic, or invalid."""
+
+    pass
+
+
 # Service mode exceptions
 
 

--- a/src/do_app_sandbox/sandbox.py
+++ b/src/do_app_sandbox/sandbox.py
@@ -964,6 +964,93 @@ class Sandbox:
             sandbox=self, snapshot_id=snapshot_id, target_path=target_path, timeout=timeout
         )
 
+    def create_incremental_snapshot(
+        self,
+        parent_snapshot_id: str,
+        snapshot_id: str | None = None,
+        paths: list[str] | None = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
+        timeout: int = 600,
+    ) -> SnapshotMetadata:
+        """Create an incremental snapshot relative to a parent.
+
+        Only captures files changed since the parent snapshot.
+        Falls back to full snapshot if the container was recycled.
+
+        Args:
+            parent_snapshot_id: ID of the parent snapshot
+            snapshot_id: Optional unique ID (auto-generated if not provided)
+            paths: Paths to include (defaults to mode-appropriate directory)
+            description: Optional human-readable description
+            tags: Optional key-value tags
+            timeout: Timeout in seconds
+
+        Returns:
+            SnapshotMetadata with snapshot_type="incremental"
+
+        Example:
+            >>> base = sandbox.create_snapshot(description="Base")
+            >>> sandbox.exec("echo 'v2' > /home/sandbox/app/version.txt")
+            >>> incr = sandbox.create_incremental_snapshot(
+            ...     parent_snapshot_id=base.snapshot_id,
+            ...     description="Version bump",
+            ... )
+            >>> print(f"Incremental: {incr.size_bytes} bytes")  # ~50 bytes vs ~250MB
+        """
+        self._ensure_awake()
+
+        if paths is None:
+            if self._mode == SandboxMode.SERVICE:
+                paths = ["/workspace"]
+            else:
+                paths = ["/home/sandbox/app"]
+
+        from .snapshot import SnapshotManager
+
+        snapshot_mgr = SnapshotManager(self._spaces_config)
+        return snapshot_mgr.create_incremental_snapshot(
+            sandbox=self,
+            parent_snapshot_id=parent_snapshot_id,
+            snapshot_id=snapshot_id,
+            paths=paths,
+            description=description,
+            tags=tags,
+            timeout=timeout,
+        )
+
+    def restore_snapshot_chain(
+        self,
+        snapshot_id: str,
+        target_path: str = "/",
+        timeout: int = 600,
+    ) -> bool:
+        """Restore a snapshot by applying its full chain.
+
+        Resolves the chain from root full snapshot through all incremental
+        layers, applying them in order. Handles file deletions at each step.
+
+        Args:
+            snapshot_id: ID of snapshot to restore (can be any in chain)
+            target_path: Base path for extraction
+            timeout: Timeout in seconds
+
+        Returns:
+            True if restoration succeeded
+
+        Example:
+            >>> new_sandbox.restore_snapshot_chain(incr2.snapshot_id)
+            # Applies: base (full) → incr1 → incr2
+        """
+        self._ensure_awake()
+
+        from .snapshot import SnapshotManager
+
+        snapshot_mgr = SnapshotManager(self._spaces_config)
+        return snapshot_mgr.restore_snapshot_chain(
+            sandbox=self, snapshot_id=snapshot_id, target_path=target_path, timeout=timeout
+        )
+
     # =========================================================================
     # Hibernation
     # =========================================================================

--- a/src/do_app_sandbox/snapshot.py
+++ b/src/do_app_sandbox/snapshot.py
@@ -16,13 +16,18 @@ import uuid
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
+import logging
+
 from .exceptions import (
+    SnapshotChainError,
     SnapshotError,
     SnapshotNotFoundError,
     SnapshotRestoreError,
     SnapshotUploadError,
     SpacesNotConfiguredError,
 )
+
+logger = logging.getLogger(__name__)
 from .spaces import SpacesClient
 from .types import SnapshotMetadata, SpacesConfig
 
@@ -174,6 +179,20 @@ class SnapshotManager:
         if not upload_result.success:
             raise SnapshotUploadError(f"Failed to upload snapshot: {upload_result.stderr}")
 
+        # Generate and store manifest (sorted file list for incremental diffing)
+        paths_str_abs = " ".join(paths)
+        find_excludes = " ".join(
+            f"-not -path '*/{p}/*'" if p.endswith("/") else f"-not -path '*/{p}'" if "/" not in p else f"-not -path '*/{p}'"
+            for p in exclude_patterns
+            if not p.startswith("*")
+        )
+        manifest_cmd = f"find {paths_str_abs} -type f {find_excludes} -printf '%P\\n' 2>/dev/null | sort"
+        manifest_result = sandbox.exec(manifest_cmd, timeout=timeout)
+        manifest_content = manifest_result.stdout if manifest_result.success else ""
+
+        manifest_key = f"{self._prefix}{snapshot_id}/manifest.txt"
+        self._spaces.put_object(manifest_key, manifest_content.encode(), content_type="text/plain")
+
         # Create and save metadata
         metadata = SnapshotMetadata(
             snapshot_id=snapshot_id,
@@ -183,8 +202,12 @@ class SnapshotManager:
             paths=paths,
             description=description,
             tags=tags or {},
+            snapshot_type="full",
         )
         self._save_metadata(metadata)
+
+        # Touch marker file for incremental snapshot support
+        sandbox.exec(f"touch /tmp/.snapshot_marker_{snapshot_id}")
 
         # Cleanup archive in sandbox
         sandbox.exec(f"rm -f {archive}")
@@ -398,3 +421,277 @@ class SnapshotManager:
         self._save_metadata(metadata)
 
         return metadata
+
+    # =========================================================================
+    # Incremental Snapshots
+    # =========================================================================
+
+    def resolve_chain(self, snapshot_id: str) -> list[SnapshotMetadata]:
+        """Walk parent links to build the ordered snapshot chain.
+
+        Returns a list ordered [root_full, incr_1, ..., target].
+
+        Raises:
+            SnapshotChainError: If chain is broken, cyclic, or doesn't
+                terminate at a full snapshot
+        """
+        chain: list[SnapshotMetadata] = []
+        visited: set[str] = set()
+        current_id: str | None = snapshot_id
+
+        while current_id is not None:
+            if current_id in visited:
+                raise SnapshotChainError(f"Cycle detected at {current_id}")
+
+            meta = self.get_snapshot(current_id)
+            if meta is None:
+                raise SnapshotChainError(f"Broken chain: {current_id} not found")
+
+            visited.add(current_id)
+            chain.append(meta)
+
+            if meta.snapshot_type == "full" or meta.parent_snapshot_id is None:
+                break
+
+            current_id = meta.parent_snapshot_id
+
+        # Verify chain terminates at a full snapshot
+        if chain and chain[-1].snapshot_type != "full":
+            raise SnapshotChainError(
+                f"Chain does not terminate at a full snapshot "
+                f"(tip: {chain[-1].snapshot_id}, type: {chain[-1].snapshot_type})"
+            )
+
+        # Reverse so root is first: [root_full, incr_1, ..., target]
+        chain.reverse()
+        return chain
+
+    def create_incremental_snapshot(
+        self,
+        sandbox: "Sandbox",
+        parent_snapshot_id: str,
+        snapshot_id: str | None = None,
+        paths: list[str] | None = None,
+        exclude_patterns: list[str] | None = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
+        timeout: int = 600,
+    ) -> SnapshotMetadata:
+        """Create a snapshot containing only files changed since the parent.
+
+        Uses `find -newer` with a marker file for change detection and
+        manifest comparison for deletion tracking.
+
+        Falls back to a full snapshot if the marker file is missing
+        (e.g., container was recycled).
+
+        Args:
+            sandbox: Sandbox to snapshot
+            parent_snapshot_id: ID of the parent snapshot
+            snapshot_id: Optional unique ID (auto-generated if not provided)
+            paths: Paths to include (default: mode-appropriate working directory)
+            exclude_patterns: Patterns to exclude (default: caches only)
+            description: Optional human-readable description
+            tags: Optional key-value tags
+            timeout: Timeout for operations in seconds
+
+        Returns:
+            SnapshotMetadata with snapshot_type="incremental"
+
+        Raises:
+            SnapshotError: If snapshot creation fails
+            SnapshotNotFoundError: If parent snapshot doesn't exist
+        """
+        # Validate parent exists
+        parent = self.get_snapshot(parent_snapshot_id)
+        if parent is None:
+            raise SnapshotNotFoundError(f"Parent snapshot not found: {parent_snapshot_id}")
+
+        # Check marker file
+        marker_path = f"/tmp/.snapshot_marker_{parent_snapshot_id}"
+        marker_check = sandbox.exec(f"test -f {marker_path} && echo EXISTS || echo MISSING")
+
+        if "MISSING" in marker_check.stdout:
+            logger.warning(
+                "Marker file missing for %s — falling back to full snapshot "
+                "(container may have been recycled)",
+                parent_snapshot_id,
+            )
+            return self.create_snapshot(
+                sandbox=sandbox,
+                snapshot_id=snapshot_id,
+                paths=paths,
+                exclude_patterns=exclude_patterns,
+                description=description,
+                tags=tags,
+                timeout=timeout,
+            )
+
+        snapshot_id = snapshot_id or f"snap-{uuid.uuid4().hex[:12]}"
+        paths = paths or DEFAULT_SNAPSHOT_PATHS
+        exclude_patterns = exclude_patterns or DEFAULT_EXCLUDE_PATTERNS
+
+        paths_str_abs = " ".join(paths)
+
+        # Build find exclusions for -newer search
+        find_excludes = []
+        for p in exclude_patterns:
+            if p.endswith("/"):
+                find_excludes.append(f"-not -path '*/{p}*'")
+            elif "*" in p:
+                find_excludes.append(f"-not -name '{p}'")
+            else:
+                find_excludes.append(f"-not -path '*/{p}/*' -not -name '{p}'")
+        find_exclude_str = " ".join(find_excludes)
+
+        # Find changed files since marker
+        find_cmd = (
+            f"find {paths_str_abs} -newer {marker_path} "
+            f"{find_exclude_str} "
+            f"-type f > /tmp/changed_files_{snapshot_id}.txt 2>/dev/null; "
+            f"wc -l < /tmp/changed_files_{snapshot_id}.txt"
+        )
+        find_result = sandbox.exec(find_cmd, timeout=timeout)
+        files_changed = int(find_result.stdout.strip()) if find_result.success else 0
+
+        # Generate current manifest
+        manifest_cmd = f"find {paths_str_abs} {find_exclude_str} -type f -printf '%P\\n' 2>/dev/null | sort"
+        manifest_result = sandbox.exec(manifest_cmd, timeout=timeout)
+        current_manifest = manifest_result.stdout if manifest_result.success else ""
+
+        # Download parent manifest and compute deletions
+        parent_manifest_key = f"{self._prefix}{parent_snapshot_id}/manifest.txt"
+        files_deleted = 0
+        try:
+            parent_manifest_bytes = self._spaces.get_object(parent_manifest_key)
+            parent_manifest = parent_manifest_bytes.decode()
+
+            # Compute deletions: files in parent but not in current
+            parent_set = set(parent_manifest.strip().splitlines())
+            current_set = set(current_manifest.strip().splitlines())
+            deleted_files = sorted(parent_set - current_set)
+            files_deleted = len(deleted_files)
+            deletions_content = "\n".join(deleted_files) + "\n" if deleted_files else ""
+        except Exception:
+            # No parent manifest available — skip deletion tracking
+            deletions_content = ""
+            logger.warning("Could not retrieve parent manifest for %s", parent_snapshot_id)
+
+        # Create incremental archive from changed files only
+        archive = f"/tmp/snapshot_{snapshot_id}.tar.gz"
+        size_bytes = 0
+
+        if files_changed > 0:
+            tar_cmd = f"tar -czf {archive} -C / -T /tmp/changed_files_{snapshot_id}.txt"
+            tar_result = sandbox.exec(tar_cmd, timeout=timeout)
+            if not tar_result.success:
+                raise SnapshotError(f"Failed to create incremental archive: {tar_result.stderr}")
+
+            size_result = sandbox.exec(f"stat -c %s {archive}")
+            if size_result.success:
+                size_bytes = int(size_result.stdout.strip())
+
+            # Upload archive
+            archive_key = f"{self._prefix}{snapshot_id}/archive.tar.gz"
+            upload_url = self._spaces.generate_presigned_upload_url(archive_key, expires_in=3600)
+            upload_result = sandbox.exec(f"curl -sSf -X PUT -T {archive} '{upload_url}'", timeout=timeout)
+            if not upload_result.success:
+                raise SnapshotUploadError(f"Failed to upload incremental snapshot: {upload_result.stderr}")
+
+        # Store manifest
+        manifest_key = f"{self._prefix}{snapshot_id}/manifest.txt"
+        self._spaces.put_object(manifest_key, current_manifest.encode(), content_type="text/plain")
+
+        # Store deletions.txt if any
+        if files_deleted > 0:
+            deletions_key = f"{self._prefix}{snapshot_id}/deletions.txt"
+            self._spaces.put_object(deletions_key, deletions_content.encode(), content_type="text/plain")
+
+        # Save metadata
+        metadata = SnapshotMetadata(
+            snapshot_id=snapshot_id,
+            created_at=time.time(),
+            sandbox_image=sandbox._image,
+            size_bytes=size_bytes,
+            paths=paths,
+            description=description,
+            tags=tags or {},
+            snapshot_type="incremental",
+            parent_snapshot_id=parent_snapshot_id,
+            chain_depth=parent.chain_depth + 1,
+            chain_root_id=parent.chain_root_id or parent.snapshot_id,
+            files_changed=files_changed,
+            files_deleted=files_deleted,
+        )
+        self._save_metadata(metadata)
+
+        # Touch new marker
+        sandbox.exec(f"touch /tmp/.snapshot_marker_{snapshot_id}")
+
+        # Cleanup temp files
+        sandbox.exec(f"rm -f {archive} /tmp/changed_files_{snapshot_id}.txt")
+
+        return metadata
+
+    def restore_snapshot_chain(
+        self,
+        sandbox: "Sandbox",
+        snapshot_id: str,
+        target_path: str = "/",
+        timeout: int = 600,
+    ) -> bool:
+        """Restore a snapshot by applying its entire chain.
+
+        Resolves the chain from root full snapshot through all incremental
+        layers, applying them in order. Handles file deletions at each layer.
+
+        Args:
+            sandbox: Sandbox to restore to
+            snapshot_id: ID of the snapshot to restore (can be any in chain)
+            target_path: Base path for extraction (default: /)
+            timeout: Timeout for operations in seconds
+
+        Returns:
+            True if restoration succeeded
+
+        Raises:
+            SnapshotChainError: If chain resolution fails
+            SnapshotRestoreError: If restoration fails
+        """
+        chain = self.resolve_chain(snapshot_id)
+
+        for meta in chain:
+            # Skip layers with no archive (empty incrementals)
+            if meta.size_bytes == 0 and meta.snapshot_type == "incremental":
+                logger.info("Skipping empty incremental layer: %s", meta.snapshot_id)
+            else:
+                # Extract archive
+                archive_key = f"{self._prefix}{meta.snapshot_id}/archive.tar.gz"
+                download_url = self._spaces.generate_presigned_download_url(archive_key, expires_in=3600)
+                restore_cmd = f"curl -sSfL '{download_url}' | tar -xzf - -C {target_path}"
+                result = sandbox.exec(restore_cmd, timeout=timeout)
+                if not result.success:
+                    raise SnapshotRestoreError(
+                        f"Failed to restore layer {meta.snapshot_id}: {result.stderr}"
+                    )
+
+            # Process deletions for incremental layers
+            if meta.snapshot_type == "incremental" and meta.files_deleted > 0:
+                deletions_key = f"{self._prefix}{meta.snapshot_id}/deletions.txt"
+                try:
+                    deletions_bytes = self._spaces.get_object(deletions_key)
+                    deletions = deletions_bytes.decode().strip()
+                    if deletions:
+                        # Determine the base path for deletions from snapshot paths
+                        base_path = meta.paths[0] if meta.paths else "/workspace"
+                        # Batch-delete using xargs
+                        delete_cmd = f"echo '{deletions}' | xargs -d '\\n' -I{{}} rm -f '{base_path}/{{}}'"
+                        sandbox.exec(delete_cmd, timeout=timeout)
+                except Exception as e:
+                    logger.warning("Could not process deletions for %s: %s", meta.snapshot_id, e)
+
+        # Touch marker for the most recent snapshot in chain
+        tip = chain[-1]
+        sandbox.exec(f"touch /tmp/.snapshot_marker_{tip.snapshot_id}")
+
+        return True

--- a/src/do_app_sandbox/types.py
+++ b/src/do_app_sandbox/types.py
@@ -89,9 +89,21 @@ class SnapshotMetadata:
     description: str | None = None
     tags: dict[str, str] = field(default_factory=dict)
 
+    # Incremental snapshot fields (all have defaults for backward compatibility)
+    snapshot_type: str = "full"  # "full" | "incremental"
+    parent_snapshot_id: str | None = None
+    chain_depth: int = 0  # 0 for full, N for Nth incremental in chain
+    chain_root_id: str | None = None
+    files_changed: int = 0
+    files_deleted: int = 0
+    dep_layer_id: str | None = None
+    lockfile_hash: str | None = None
+
     def __repr__(self) -> str:
         size_mb = self.size_bytes / (1024 * 1024)
-        return f"SnapshotMetadata(id={self.snapshot_id!r}, size={size_mb:.1f}MB)"
+        type_str = f", type={self.snapshot_type}" if self.snapshot_type != "full" else ""
+        chain_str = f", chain_depth={self.chain_depth}" if self.chain_depth > 0 else ""
+        return f"SnapshotMetadata(id={self.snapshot_id!r}, size={size_mb:.1f}MB{type_str}{chain_str})"
 
 
 @dataclass

--- a/tests/e2e_incremental_snapshot_validation.py
+++ b/tests/e2e_incremental_snapshot_validation.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""E2E Incremental Snapshot Chain Validation.
+
+Tests the full incremental snapshot lifecycle:
+1. Create sandbox → write files → full snapshot (base)
+2. Edit files → incremental snapshot #1
+3. Delete file + edit file → incremental snapshot #2
+4. Create new sandbox → restore_snapshot_chain from #2 → verify ALL state
+
+This validates: marker-based change detection, manifest diffing,
+deletion tracking, chain resolution, and multi-layer restore.
+
+Usage:
+    PYTHONPATH=src:$PYTHONPATH python tests/e2e_incremental_snapshot_validation.py
+"""
+
+import json
+import os
+import sys
+import time
+import traceback
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from do_app_sandbox import Sandbox, SnapshotManager
+from do_app_sandbox.spaces import create_spaces_config_from_env
+
+# ── Logging ────────────────────────────────────────────────────────────────
+
+LOG_FILE = os.path.join(os.path.dirname(__file__), "artifacts", "incremental_snapshot_validation.log")
+os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+
+def log(msg: str, level: str = "INFO"):
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    line = f"[{ts}] [{level}] {msg}"
+    print(line, flush=True)
+    with open(LOG_FILE, "a") as f:
+        f.write(line + "\n")
+
+# ── Cleanup tracker ───────────────────────────────────────────────────────
+
+sandboxes_to_cleanup: list = []
+snapshots_to_cleanup: list[str] = []
+results: list[dict] = []
+
+def record(name: str, passed: bool, duration: float, details: str = ""):
+    status = "PASS" if passed else "FAIL"
+    results.append({"test": name, "passed": passed, "duration_s": round(duration, 1), "details": details})
+    log(f"  {status}: {name} ({round(duration, 1)}s) {details}", "RESULT")
+
+
+def check_env():
+    required = ["DIGITALOCEAN_TOKEN", "SPACES_BUCKET", "SPACES_REGION", "SPACES_ACCESS_KEY", "SPACES_SECRET_KEY"]
+    missing = [v for v in required if not os.environ.get(v)]
+    if missing:
+        log(f"Missing env vars: {', '.join(missing)}", "ERROR")
+        sys.exit(1)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+def test_1_create_sandbox():
+    """Create sandbox with Spaces config."""
+    log("Test 1: Create sandbox")
+    t0 = time.time()
+
+    sandbox = Sandbox.create(
+        image="python",
+        spaces_config=create_spaces_config_from_env(),
+        wait_ready=True,
+        timeout=300,
+    )
+    sandboxes_to_cleanup.append(sandbox)
+    assert sandbox.exec("echo ok").exit_code == 0
+
+    record("create_sandbox", True, time.time() - t0, f"app_id={sandbox._app_id}")
+    return sandbox
+
+
+def test_2_write_initial_files(sandbox):
+    """Write initial file set for the base snapshot."""
+    log("Test 2: Write initial files")
+    t0 = time.time()
+
+    sandbox.exec("mkdir -p /home/sandbox/app/src /home/sandbox/app/data")
+    sandbox.exec("echo 'print(\"hello\")' > /home/sandbox/app/src/main.py")
+    sandbox.exec("echo 'import os' > /home/sandbox/app/src/utils.py")
+    sandbox.exec("echo '{\"version\": 1}' > /home/sandbox/app/data/config.json")
+    sandbox.exec("echo 'README content' > /home/sandbox/app/README.md")
+
+    result = sandbox.exec("find /home/sandbox/app -type f | sort")
+    log(f"  Initial files:\n{result.stdout}")
+
+    record("write_initial_files", True, time.time() - t0, "4 files written")
+
+
+def test_3_create_base_snapshot(sandbox):
+    """Create full base snapshot."""
+    log("Test 3: Create base snapshot (full)")
+    t0 = time.time()
+
+    base = sandbox.create_snapshot(
+        snapshot_id=f"snap-base-{int(time.time())}",
+        description="Base snapshot with 4 files",
+        tags={"chain": "test", "layer": "base"},
+    )
+    snapshots_to_cleanup.append(base.snapshot_id)
+
+    assert base.snapshot_type == "full"
+    assert base.chain_depth == 0
+    assert base.parent_snapshot_id is None
+    assert base.size_bytes > 0
+
+    # Verify marker was created
+    marker_check = sandbox.exec(f"test -f /tmp/.snapshot_marker_{base.snapshot_id} && echo EXISTS")
+    assert "EXISTS" in marker_check.stdout, "Marker file not created"
+
+    # Verify manifest was stored
+    mgr = SnapshotManager(spaces_config=create_spaces_config_from_env())
+    manifest_key = f"snapshots/{base.snapshot_id}/manifest.txt"
+    manifest = mgr._spaces.get_object(manifest_key).decode()
+    log(f"  Base manifest:\n{manifest}")
+    assert "src/main.py" in manifest
+    assert "README.md" in manifest
+
+    record("create_base_snapshot", True, time.time() - t0,
+           f"id={base.snapshot_id}, size={base.size_bytes}B, type={base.snapshot_type}")
+    return base
+
+
+def test_4_edit_files_and_incremental_1(sandbox, base):
+    """Edit 2 files, add 1 new file → incremental snapshot #1."""
+    log("Test 4: Edit files → incremental snapshot #1")
+    t0 = time.time()
+
+    # Edit main.py
+    sandbox.exec("echo 'print(\"hello v2\")' > /home/sandbox/app/src/main.py")
+    # Edit config
+    sandbox.exec("echo '{\"version\": 2, \"updated\": true}' > /home/sandbox/app/data/config.json")
+    # Add new file
+    sandbox.exec("echo 'new module' > /home/sandbox/app/src/newmodule.py")
+
+    incr1 = sandbox.create_incremental_snapshot(
+        parent_snapshot_id=base.snapshot_id,
+        snapshot_id=f"snap-incr1-{int(time.time())}",
+        description="Edited main.py, config.json; added newmodule.py",
+        tags={"chain": "test", "layer": "incr1"},
+    )
+    snapshots_to_cleanup.append(incr1.snapshot_id)
+
+    assert incr1.snapshot_type == "incremental"
+    assert incr1.parent_snapshot_id == base.snapshot_id
+    assert incr1.chain_depth == 1
+    assert incr1.files_changed >= 2, f"Expected >=2 changed, got {incr1.files_changed}"
+    assert incr1.files_deleted == 0
+    assert incr1.size_bytes < base.size_bytes, "Incremental should be smaller than full"
+
+    log(f"  Incremental 1: {incr1.size_bytes}B (base was {base.size_bytes}B), "
+        f"changed={incr1.files_changed}, deleted={incr1.files_deleted}")
+
+    record("incremental_snapshot_1", True, time.time() - t0,
+           f"id={incr1.snapshot_id}, size={incr1.size_bytes}B, changed={incr1.files_changed}")
+    return incr1
+
+
+def test_5_delete_and_edit_then_incremental_2(sandbox, incr1):
+    """Delete 1 file, edit 1 file → incremental snapshot #2."""
+    log("Test 5: Delete + edit → incremental snapshot #2")
+    t0 = time.time()
+
+    # Delete utils.py
+    sandbox.exec("rm /home/sandbox/app/src/utils.py")
+    # Edit README
+    sandbox.exec("echo 'README v2 - updated' > /home/sandbox/app/README.md")
+
+    incr2 = sandbox.create_incremental_snapshot(
+        parent_snapshot_id=incr1.snapshot_id,
+        snapshot_id=f"snap-incr2-{int(time.time())}",
+        description="Deleted utils.py, edited README.md",
+        tags={"chain": "test", "layer": "incr2"},
+    )
+    snapshots_to_cleanup.append(incr2.snapshot_id)
+
+    assert incr2.snapshot_type == "incremental"
+    assert incr2.parent_snapshot_id == incr1.snapshot_id
+    assert incr2.chain_depth == 2
+    assert incr2.files_deleted >= 1, f"Expected >=1 deleted, got {incr2.files_deleted}"
+
+    log(f"  Incremental 2: {incr2.size_bytes}B, "
+        f"changed={incr2.files_changed}, deleted={incr2.files_deleted}")
+
+    record("incremental_snapshot_2", True, time.time() - t0,
+           f"id={incr2.snapshot_id}, changed={incr2.files_changed}, deleted={incr2.files_deleted}")
+    return incr2
+
+
+def test_6_resolve_chain(base, incr1, incr2):
+    """Verify resolve_chain returns correct ordered chain."""
+    log("Test 6: Resolve chain")
+    t0 = time.time()
+
+    mgr = SnapshotManager(spaces_config=create_spaces_config_from_env())
+    chain = mgr.resolve_chain(incr2.snapshot_id)
+
+    assert len(chain) == 3, f"Expected 3 links, got {len(chain)}"
+    assert chain[0].snapshot_id == base.snapshot_id, "First should be base (full)"
+    assert chain[0].snapshot_type == "full"
+    assert chain[1].snapshot_id == incr1.snapshot_id
+    assert chain[1].snapshot_type == "incremental"
+    assert chain[2].snapshot_id == incr2.snapshot_id
+    assert chain[2].snapshot_type == "incremental"
+
+    chain_str = " → ".join(f"{m.snapshot_id}({m.snapshot_type})" for m in chain)
+    log(f"  Chain: {chain_str}")
+
+    record("resolve_chain", True, time.time() - t0, f"chain length={len(chain)}")
+
+
+def test_7_restore_chain_to_new_sandbox(incr2):
+    """Create new sandbox, restore from chain tip, verify ALL state."""
+    log("Test 7: Restore chain to new sandbox")
+    t0 = time.time()
+
+    sandbox2 = Sandbox.create(
+        image="python",
+        spaces_config=create_spaces_config_from_env(),
+        wait_ready=True,
+        timeout=300,
+    )
+    sandboxes_to_cleanup.append(sandbox2)
+
+    # Restore the full chain from incr2 (resolves: base → incr1 → incr2)
+    success = sandbox2.restore_snapshot_chain(incr2.snapshot_id)
+    assert success is True
+
+    # ── Verify expected state after chain restore ──
+
+    errors = []
+
+    # Files from base that were NOT deleted should exist
+    # main.py was edited in incr1 → should have v2 content
+    r = sandbox2.exec("cat /home/sandbox/app/src/main.py")
+    if 'hello v2' not in r.stdout:
+        errors.append(f"main.py: expected 'hello v2', got {r.stdout.strip()!r}")
+
+    # config.json was edited in incr1 → should have v2 content
+    r = sandbox2.exec("cat /home/sandbox/app/data/config.json")
+    if '"version": 2' not in r.stdout:
+        errors.append(f"config.json: expected version 2, got {r.stdout.strip()!r}")
+
+    # newmodule.py was added in incr1 → should exist
+    r = sandbox2.exec("cat /home/sandbox/app/src/newmodule.py")
+    if 'new module' not in r.stdout:
+        errors.append(f"newmodule.py: expected 'new module', got {r.stdout.strip()!r}")
+
+    # README.md was edited in incr2 → should have v2 content
+    r = sandbox2.exec("cat /home/sandbox/app/README.md")
+    if 'README v2' not in r.stdout:
+        errors.append(f"README.md: expected 'README v2', got {r.stdout.strip()!r}")
+
+    # utils.py was DELETED in incr2 → should NOT exist
+    r = sandbox2.exec("test -f /home/sandbox/app/src/utils.py && echo EXISTS || echo GONE")
+    if 'GONE' not in r.stdout:
+        errors.append(f"utils.py: should be deleted but still exists")
+
+    # List final file state
+    r = sandbox2.exec("find /home/sandbox/app -type f | sort")
+    log(f"  Restored files:\n{r.stdout}")
+
+    if errors:
+        for e in errors:
+            log(f"  VERIFICATION ERROR: {e}", "ERROR")
+        record("restore_chain_verify", False, time.time() - t0, "; ".join(errors))
+        return False
+    else:
+        record("restore_chain_verify", True, time.time() - t0,
+               "all edits applied, deletion confirmed, chain fully restored")
+        return True
+
+
+def test_8_resolve_chain_for_full_snapshot(base):
+    """Verify resolve_chain on a full snapshot returns single element."""
+    log("Test 8: Resolve chain for full snapshot (single element)")
+    t0 = time.time()
+
+    mgr = SnapshotManager(spaces_config=create_spaces_config_from_env())
+    chain = mgr.resolve_chain(base.snapshot_id)
+
+    assert len(chain) == 1, f"Expected 1, got {len(chain)}"
+    assert chain[0].snapshot_type == "full"
+
+    record("resolve_chain_single", True, time.time() - t0, "single full snapshot in chain")
+
+
+def test_9_chain_error_handling():
+    """Verify broken chain raises SnapshotChainError."""
+    log("Test 9: Chain error handling")
+    t0 = time.time()
+
+    from do_app_sandbox.exceptions import SnapshotChainError
+
+    mgr = SnapshotManager(spaces_config=create_spaces_config_from_env())
+
+    try:
+        mgr.resolve_chain("nonexistent-snapshot-xyz")
+        record("chain_error_handling", False, time.time() - t0, "Expected SnapshotChainError")
+    except SnapshotChainError as e:
+        assert "not found" in str(e).lower() or "broken" in str(e).lower()
+        record("chain_error_handling", True, time.time() - t0, f"correctly raised: {e}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+def cleanup():
+    log("Cleaning up resources...")
+    spaces_config = create_spaces_config_from_env()
+    mgr = SnapshotManager(spaces_config=spaces_config)
+
+    for snap_id in snapshots_to_cleanup:
+        try:
+            # Also clean manifest.txt and deletions.txt
+            for suffix in ["archive.tar.gz", "metadata.json", "manifest.txt", "deletions.txt"]:
+                key = f"snapshots/{snap_id}/{suffix}"
+                try:
+                    mgr._spaces.delete_object(key)
+                except Exception:
+                    pass
+            log(f"  Deleted snapshot: {snap_id}")
+        except Exception as e:
+            log(f"  Failed to delete snapshot {snap_id}: {e}", "WARN")
+
+    for sandbox in sandboxes_to_cleanup:
+        try:
+            sandbox.delete()
+            log(f"  Deleted sandbox: {sandbox._app_id}")
+        except Exception as e:
+            log(f"  Failed to delete sandbox: {e}", "WARN")
+
+
+def main():
+    log("=" * 70)
+    log("Incremental Snapshot Chain E2E Validation")
+    log("=" * 70)
+
+    check_env()
+    t_start = time.time()
+
+    try:
+        sandbox = test_1_create_sandbox()
+        test_2_write_initial_files(sandbox)
+        base = test_3_create_base_snapshot(sandbox)
+        incr1 = test_4_edit_files_and_incremental_1(sandbox, base)
+        incr2 = test_5_delete_and_edit_then_incremental_2(sandbox, incr1)
+        test_6_resolve_chain(base, incr1, incr2)
+        test_7_restore_chain_to_new_sandbox(incr2)
+        test_8_resolve_chain_for_full_snapshot(base)
+        test_9_chain_error_handling()
+
+    except Exception as e:
+        log(f"Test failed with exception: {e}", "ERROR")
+        traceback.print_exc()
+        record("EXCEPTION", False, 0, str(e))
+
+    finally:
+        cleanup()
+
+    total_time = time.time() - t_start
+    passed = sum(1 for r in results if r["passed"])
+    failed = sum(1 for r in results if not r["passed"])
+
+    log("")
+    log("=" * 70)
+    log(f"SUMMARY: {passed} passed, {failed} failed, {round(total_time, 1)}s total")
+    log("=" * 70)
+    for r in results:
+        status = "PASS" if r["passed"] else "FAIL"
+        log(f"  [{status}] {r['test']} ({r['duration_s']}s) {r['details']}")
+
+    report_path = os.path.join(os.path.dirname(__file__), "artifacts", "incremental_snapshot_report.json")
+    with open(report_path, "w") as f:
+        json.dump({"results": results, "total_time_s": round(total_time, 1), "passed": passed, "failed": failed}, f, indent=2)
+    log(f"\nReport: {report_path}")
+    log(f"Log:    {LOG_FILE}")
+
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e_snapshot_validation.py
+++ b/tests/e2e_snapshot_validation.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""E2E Snapshot Foundation Validation.
+
+Tests the snapshot infrastructure that incremental snapshots will build on.
+Requires: DIGITALOCEAN_TOKEN, SPACES_BUCKET, SPACES_REGION, SPACES_ACCESS_KEY, SPACES_SECRET_KEY
+
+Test plan:
+1. Create sandbox with Spaces config
+2. Write known test files to sandbox
+3. Create full snapshot → verify metadata
+4. Create second sandbox → restore snapshot → verify files match
+5. Test snapshot listing and filtering
+6. Test hibernate → wake → verify state restored
+7. Cleanup all resources
+
+Usage:
+    export DIGITALOCEAN_TOKEN=dop_v1_...
+    export SPACES_BUCKET=do-sandbox-snapshot-test
+    export SPACES_REGION=syd1
+    export SPACES_ACCESS_KEY=...
+    export SPACES_SECRET_KEY=...
+    python tests/e2e_snapshot_validation.py
+"""
+
+import json
+import os
+import sys
+import time
+import traceback
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from do_app_sandbox import Sandbox
+from do_app_sandbox.snapshot import SnapshotManager
+from do_app_sandbox.spaces import SpacesClient, create_spaces_config_from_env
+
+# ── Logging ────────────────────────────────────────────────────────────────
+
+LOG_FILE = os.path.join(os.path.dirname(__file__), "artifacts", "snapshot_validation.log")
+
+def log(msg: str, level: str = "INFO"):
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    line = f"[{ts}] [{level}] {msg}"
+    print(line)
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    with open(LOG_FILE, "a") as f:
+        f.write(line + "\n")
+
+def log_result(test_name: str, passed: bool, details: str = ""):
+    status = "PASS" if passed else "FAIL"
+    log(f"  {status}: {test_name}" + (f" — {details}" if details else ""), "RESULT")
+
+# ── Cleanup tracker ───────────────────────────────────────────────────────
+
+sandboxes_to_cleanup: list[Sandbox] = []
+snapshots_to_cleanup: list[str] = []
+results: list[dict] = []
+
+
+def record(name: str, passed: bool, duration: float, details: str = ""):
+    results.append({"test": name, "passed": passed, "duration_s": round(duration, 1), "details": details})
+    log_result(name, passed, f"{round(duration, 1)}s" + (f" — {details}" if details else ""))
+
+
+# ── Env check ─────────────────────────────────────────────────────────────
+
+def check_env():
+    required = ["DIGITALOCEAN_TOKEN", "SPACES_BUCKET", "SPACES_REGION", "SPACES_ACCESS_KEY", "SPACES_SECRET_KEY"]
+    missing = [v for v in required if not os.environ.get(v)]
+    if missing:
+        log(f"Missing env vars: {', '.join(missing)}", "ERROR")
+        sys.exit(1)
+    log(f"Environment OK: bucket={os.environ['SPACES_BUCKET']}, region={os.environ['SPACES_REGION']}")
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+def test_1_create_sandbox_with_spaces():
+    """Create a sandbox with Spaces config attached."""
+    log("Test 1: Create sandbox with Spaces config")
+    t0 = time.time()
+
+    spaces_config = create_spaces_config_from_env()
+    sandbox = Sandbox.create(
+        image="python",
+        spaces_config=spaces_config,
+        wait_ready=True,
+        timeout=300,
+    )
+    sandboxes_to_cleanup.append(sandbox)
+
+    # Verify sandbox is functional
+    result = sandbox.exec("echo 'sandbox-alive'")
+    assert result.exit_code == 0, f"exec failed: {result.stderr}"
+    assert "sandbox-alive" in result.stdout
+
+    dur = time.time() - t0
+    record("create_sandbox_with_spaces", True, dur, f"app_id={sandbox._app_id}")
+    return sandbox
+
+
+def test_2_write_test_files(sandbox: Sandbox):
+    """Write known test files to the sandbox."""
+    log("Test 2: Write test files to sandbox")
+    t0 = time.time()
+
+    test_files = {
+        "/home/sandbox/app/hello.txt": "Hello from snapshot test!",
+        "/home/sandbox/app/data/config.json": '{"version": 1, "name": "snapshot-test"}',
+        "/home/sandbox/app/src/main.py": 'print("Snapshot foundation test")',
+    }
+
+    sandbox.exec("mkdir -p /home/sandbox/app/data /home/sandbox/app/src")
+    for path, content in test_files.items():
+        result = sandbox.exec(f"echo '{content}' > {path}")
+        assert result.exit_code == 0, f"Failed to write {path}: {result.stderr}"
+
+    # Verify files exist
+    result = sandbox.exec("find /home/sandbox/app -type f | sort")
+    assert result.exit_code == 0
+    log(f"  Files in sandbox: {result.stdout.strip()}")
+
+    dur = time.time() - t0
+    record("write_test_files", True, dur, f"{len(test_files)} files")
+    return test_files
+
+
+def test_3_create_snapshot(sandbox: Sandbox):
+    """Create a full snapshot and verify metadata."""
+    log("Test 3: Create snapshot")
+    t0 = time.time()
+
+    metadata = sandbox.create_snapshot(
+        snapshot_id=f"snap-e2e-{int(time.time())}",
+        description="E2E validation snapshot",
+        tags={"purpose": "e2e-test", "image": "python"},
+    )
+    snapshots_to_cleanup.append(metadata.snapshot_id)
+
+    # Verify metadata fields
+    assert metadata.snapshot_id.startswith("snap-e2e-"), f"Bad ID: {metadata.snapshot_id}"
+    assert metadata.sandbox_image == "python"
+    assert metadata.size_bytes > 0, f"Empty snapshot: {metadata.size_bytes}"
+    assert metadata.description == "E2E validation snapshot"
+    assert metadata.tags["purpose"] == "e2e-test"
+
+    dur = time.time() - t0
+    record("create_snapshot", True, dur, f"id={metadata.snapshot_id}, size={metadata.size_bytes} bytes")
+    return metadata
+
+
+def test_4_verify_snapshot_in_spaces(snapshot_id: str):
+    """Verify snapshot metadata and archive exist in Spaces."""
+    log("Test 4: Verify snapshot in Spaces")
+    t0 = time.time()
+
+    spaces_config = create_spaces_config_from_env()
+    manager = SnapshotManager(spaces_config=spaces_config)
+
+    # Check existence
+    assert manager.snapshot_exists(snapshot_id), f"Snapshot {snapshot_id} not found in Spaces"
+
+    # Retrieve metadata
+    meta = manager.get_snapshot(snapshot_id)
+    assert meta is not None, "Metadata retrieval returned None"
+    assert meta.snapshot_id == snapshot_id
+    assert meta.size_bytes > 0
+
+    # Verify download URL can be generated
+    url = manager.get_snapshot_download_url(snapshot_id)
+    assert url.startswith("https://"), f"Bad URL: {url}"
+
+    dur = time.time() - t0
+    record("verify_snapshot_in_spaces", True, dur, f"metadata OK, download URL generated")
+
+
+def test_5_restore_to_new_sandbox(snapshot_id: str, original_files: dict):
+    """Create a second sandbox, restore snapshot, verify files match."""
+    log("Test 5: Restore snapshot to new sandbox")
+    t0 = time.time()
+
+    spaces_config = create_spaces_config_from_env()
+    sandbox2 = Sandbox.create(
+        image="python",
+        spaces_config=spaces_config,
+        wait_ready=True,
+        timeout=300,
+    )
+    sandboxes_to_cleanup.append(sandbox2)
+
+    # Restore
+    success = sandbox2.restore_snapshot(snapshot_id)
+    assert success is True, "restore_snapshot returned False"
+
+    # Verify each file
+    mismatches = []
+    for path, expected_content in original_files.items():
+        result = sandbox2.exec(f"cat {path}")
+        if result.exit_code != 0:
+            mismatches.append(f"{path}: file missing ({result.stderr})")
+        elif expected_content not in result.stdout:
+            mismatches.append(f"{path}: content mismatch (got: {result.stdout.strip()!r})")
+
+    assert not mismatches, f"File verification failed:\n" + "\n".join(mismatches)
+
+    dur = time.time() - t0
+    record("restore_to_new_sandbox", True, dur, f"all {len(original_files)} files verified")
+    return sandbox2
+
+
+def test_6_list_and_filter_snapshots(snapshot_id: str):
+    """Test listing and filtering snapshots."""
+    log("Test 6: List and filter snapshots")
+    t0 = time.time()
+
+    spaces_config = create_spaces_config_from_env()
+    manager = SnapshotManager(spaces_config=spaces_config)
+
+    # List all
+    all_snaps = manager.list_snapshots()
+    assert any(s.snapshot_id == snapshot_id for s in all_snaps), "Created snapshot not in list"
+
+    # Filter by image
+    python_snaps = manager.list_snapshots(image="python")
+    assert all(s.sandbox_image == "python" for s in python_snaps)
+    assert any(s.snapshot_id == snapshot_id for s in python_snaps)
+
+    # Filter by non-existent image
+    node_snaps = manager.list_snapshots(image="node")
+    assert not any(s.snapshot_id == snapshot_id for s in node_snaps)
+
+    dur = time.time() - t0
+    record("list_and_filter_snapshots", True, dur, f"total={len(all_snaps)}, python={len(python_snaps)}")
+
+
+def test_7_hibernate_and_wake(original_files: dict):
+    """Test hibernate (snapshot + delete) → wake (create + restore)."""
+    log("Test 7: Hibernate and wake")
+    t0 = time.time()
+
+    spaces_config = create_spaces_config_from_env()
+
+    # Create a sandbox with content
+    sandbox = Sandbox.create(
+        image="python",
+        spaces_config=spaces_config,
+        wait_ready=True,
+        timeout=300,
+    )
+
+    # Write unique content
+    hibernate_marker = f"hibernate-test-{int(time.time())}"
+    sandbox.exec(f"mkdir -p /home/sandbox/app")
+    sandbox.exec(f"echo '{hibernate_marker}' > /home/sandbox/app/hibernate_marker.txt")
+
+    log(f"  Hibernating sandbox {sandbox._app_id}...")
+    hibernated = sandbox.hibernate()
+    snapshots_to_cleanup.append(hibernated.snapshot_id)
+    log(f"  Hibernated: snapshot_id={hibernated.snapshot_id}")
+
+    # Verify sandbox is gone (should not be accessible)
+    assert hibernated.snapshot_id.startswith("hibernate-")
+    assert hibernated.image == "python"
+
+    # Wake
+    log(f"  Waking sandbox from {hibernated.snapshot_id}...")
+    woken = Sandbox.wake(hibernated, spaces_config=spaces_config, timeout=300)
+    sandboxes_to_cleanup.append(woken)
+
+    # Verify state restored
+    result = woken.exec("cat /home/sandbox/app/hibernate_marker.txt")
+    assert result.exit_code == 0, f"Failed to read marker: {result.stderr}"
+    assert hibernate_marker in result.stdout, f"Marker mismatch: {result.stdout.strip()!r}"
+
+    dur = time.time() - t0
+    record("hibernate_and_wake", True, dur, f"marker verified after wake")
+
+
+def test_8_delete_snapshot():
+    """Test snapshot deletion."""
+    log("Test 8: Delete snapshot")
+    t0 = time.time()
+
+    spaces_config = create_spaces_config_from_env()
+
+    # Create a throwaway sandbox + snapshot
+    sandbox = Sandbox.create(
+        image="python",
+        spaces_config=spaces_config,
+        wait_ready=True,
+        timeout=300,
+    )
+    sandboxes_to_cleanup.append(sandbox)
+
+    sandbox.exec("echo 'delete-test' > /home/sandbox/app/delete_me.txt")
+    meta = sandbox.create_snapshot(snapshot_id=f"snap-delete-{int(time.time())}")
+
+    manager = SnapshotManager(spaces_config=spaces_config)
+
+    # Verify exists
+    assert manager.snapshot_exists(meta.snapshot_id)
+
+    # Delete
+    result = manager.delete_snapshot(meta.snapshot_id)
+    assert result is True
+
+    # Verify gone
+    assert not manager.snapshot_exists(meta.snapshot_id)
+
+    dur = time.time() - t0
+    record("delete_snapshot", True, dur, "snapshot deleted and verified gone")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+def cleanup():
+    """Clean up all resources."""
+    log("Cleaning up resources...")
+
+    for snap_id in snapshots_to_cleanup:
+        try:
+            spaces_config = create_spaces_config_from_env()
+            manager = SnapshotManager(spaces_config=spaces_config)
+            manager.delete_snapshot(snap_id)
+            log(f"  Deleted snapshot: {snap_id}")
+        except Exception as e:
+            log(f"  Failed to delete snapshot {snap_id}: {e}", "WARN")
+
+    for sandbox in sandboxes_to_cleanup:
+        try:
+            sandbox.delete()
+            log(f"  Deleted sandbox: {sandbox._app_id}")
+        except Exception as e:
+            log(f"  Failed to delete sandbox {sandbox._app_id}: {e}", "WARN")
+
+
+def main():
+    log("=" * 60)
+    log("Snapshot Foundation E2E Validation")
+    log("=" * 60)
+
+    check_env()
+    t_start = time.time()
+
+    try:
+        # Test 1: Create sandbox
+        sandbox1 = test_1_create_sandbox_with_spaces()
+
+        # Test 2: Write test files
+        test_files = test_2_write_test_files(sandbox1)
+
+        # Test 3: Create snapshot
+        metadata = test_3_create_snapshot(sandbox1)
+
+        # Test 4: Verify in Spaces
+        test_4_verify_snapshot_in_spaces(metadata.snapshot_id)
+
+        # Test 5: Restore to new sandbox
+        test_5_restore_to_new_sandbox(metadata.snapshot_id, test_files)
+
+        # Test 6: List and filter
+        test_6_list_and_filter_snapshots(metadata.snapshot_id)
+
+        # Test 7: Hibernate and wake
+        test_7_hibernate_and_wake(test_files)
+
+        # Test 8: Delete
+        test_8_delete_snapshot()
+
+    except Exception as e:
+        log(f"Test failed with exception: {e}", "ERROR")
+        traceback.print_exc()
+        # Record the failure for whichever test was running
+        record(f"EXCEPTION", False, 0, str(e))
+
+    finally:
+        cleanup()
+
+    # ── Summary ───────────────────────────────────────────────────────
+    total_time = time.time() - t_start
+    passed = sum(1 for r in results if r["passed"])
+    failed = sum(1 for r in results if not r["passed"])
+
+    log("")
+    log("=" * 60)
+    log(f"SUMMARY: {passed} passed, {failed} failed, {round(total_time, 1)}s total")
+    log("=" * 60)
+    for r in results:
+        status = "PASS" if r["passed"] else "FAIL"
+        log(f"  [{status}] {r['test']} ({r['duration_s']}s) {r['details']}")
+
+    # Save JSON report
+    report_path = os.path.join(os.path.dirname(__file__), "artifacts", "snapshot_validation_report.json")
+    with open(report_path, "w") as f:
+        json.dump({"results": results, "total_time_s": round(total_time, 1), "passed": passed, "failed": failed}, f, indent=2)
+    log(f"\nReport saved: {report_path}")
+
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -281,3 +281,136 @@ class TestSnapshotErrors:
 
         with pytest.raises(SnapshotNotFoundError):
             manager.get_snapshot_download_url("nonexistent-snapshot-xyz")
+
+
+# ---------------------------------------------------------------------------
+# Incremental Snapshot Chain Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.requires_own_sandbox
+@requires_all_credentials
+class TestIncrementalSnapshotChain:
+    """Tests for incremental snapshot chain: create, resolve, restore.
+
+    These tests create their own sandboxes because they modify filesystem
+    state and restore snapshots (destructive operations).
+
+    Run with: `make test-snapshot` after `make test-setup`
+    """
+
+    @pytest.mark.timeout(300)
+    def test_incremental_chain_full_lifecycle(self, do_token, spaces_config, cleanup_sandboxes, cleanup_snapshots):
+        """Full lifecycle: base → edit → incr1 → delete+edit → incr2 → restore chain (~120s)."""
+        from do_app_sandbox import Sandbox
+        from do_app_sandbox.snapshot import SnapshotManager
+
+        # Create sandbox with content
+        sandbox = Sandbox.create(image="python", api_token=do_token, spaces_config=spaces_config, wait_ready=True)
+        cleanup_sandboxes(sandbox)
+
+        # Write initial files
+        sandbox.exec("mkdir -p /home/sandbox/app/src /home/sandbox/app/data")
+        sandbox.exec("echo 'v1' > /home/sandbox/app/src/main.py")
+        sandbox.exec("echo 'utils' > /home/sandbox/app/src/utils.py")
+        sandbox.exec("echo '{\"v\": 1}' > /home/sandbox/app/data/config.json")
+
+        # Base snapshot (full)
+        base = sandbox.create_snapshot(description="Base with 3 files")
+        cleanup_snapshots(base.snapshot_id)
+
+        assert base.snapshot_type == "full"
+        assert base.chain_depth == 0
+
+        # Edit files → incremental #1
+        sandbox.exec("echo 'v2' > /home/sandbox/app/src/main.py")
+        sandbox.exec("echo 'new' > /home/sandbox/app/src/newfile.py")
+
+        incr1 = sandbox.create_incremental_snapshot(
+            parent_snapshot_id=base.snapshot_id,
+            description="Edited main, added newfile",
+        )
+        cleanup_snapshots(incr1.snapshot_id)
+
+        assert incr1.snapshot_type == "incremental"
+        assert incr1.parent_snapshot_id == base.snapshot_id
+        assert incr1.chain_depth == 1
+        assert incr1.files_changed >= 2
+
+        # Delete + edit → incremental #2
+        sandbox.exec("rm /home/sandbox/app/src/utils.py")
+        sandbox.exec("echo '{\"v\": 2}' > /home/sandbox/app/data/config.json")
+
+        incr2 = sandbox.create_incremental_snapshot(
+            parent_snapshot_id=incr1.snapshot_id,
+            description="Deleted utils, edited config",
+        )
+        cleanup_snapshots(incr2.snapshot_id)
+
+        assert incr2.snapshot_type == "incremental"
+        assert incr2.chain_depth == 2
+        assert incr2.files_deleted >= 1
+
+        # Resolve chain
+        mgr = SnapshotManager(spaces_config=spaces_config)
+        chain = mgr.resolve_chain(incr2.snapshot_id)
+        assert len(chain) == 3
+        assert chain[0].snapshot_type == "full"
+
+        # Restore chain to new sandbox
+        sandbox2 = Sandbox.create(image="python", api_token=do_token, spaces_config=spaces_config, wait_ready=True)
+        cleanup_sandboxes(sandbox2)
+
+        success = sandbox2.restore_snapshot_chain(incr2.snapshot_id)
+        assert success is True
+
+        # Verify state
+        r = sandbox2.exec("cat /home/sandbox/app/src/main.py")
+        assert "v2" in r.stdout
+
+        r = sandbox2.exec("cat /home/sandbox/app/src/newfile.py")
+        assert "new" in r.stdout
+
+        r = sandbox2.exec("cat /home/sandbox/app/data/config.json")
+        assert '"v": 2' in r.stdout
+
+        r = sandbox2.exec("test -f /home/sandbox/app/src/utils.py && echo EXISTS || echo GONE")
+        assert "GONE" in r.stdout
+
+    @pytest.mark.timeout(180)
+    def test_incremental_marker_fallback(self, do_token, spaces_config, cleanup_sandboxes, cleanup_snapshots):
+        """Missing marker falls back to full snapshot (~60s)."""
+        from do_app_sandbox import Sandbox
+
+        sandbox = Sandbox.create(image="python", api_token=do_token, spaces_config=spaces_config, wait_ready=True)
+        cleanup_sandboxes(sandbox)
+
+        sandbox.exec("echo 'content' > /home/sandbox/app/test.txt")
+        base = sandbox.create_snapshot(description="Base")
+        cleanup_snapshots(base.snapshot_id)
+
+        # Remove the marker to simulate container recycle
+        sandbox.exec(f"rm -f /tmp/.snapshot_marker_{base.snapshot_id}")
+
+        sandbox.exec("echo 'updated' > /home/sandbox/app/test.txt")
+        result = sandbox.create_incremental_snapshot(
+            parent_snapshot_id=base.snapshot_id,
+            description="Should fall back to full",
+        )
+        cleanup_snapshots(result.snapshot_id)
+
+        # Should have fallen back to full
+        assert result.snapshot_type == "full"
+        assert result.chain_depth == 0
+
+    @pytest.mark.timeout(10)
+    def test_chain_error_on_broken_chain(self, spaces_config):
+        """Resolve chain raises SnapshotChainError for missing snapshot (~2s)."""
+        from do_app_sandbox.exceptions import SnapshotChainError
+        from do_app_sandbox.snapshot import SnapshotManager
+
+        mgr = SnapshotManager(spaces_config=spaces_config)
+
+        with pytest.raises(SnapshotChainError):
+            mgr.resolve_chain("nonexistent-chain-tip")

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from do_app_sandbox.exceptions import (
+    SnapshotChainError,
     SnapshotNotFoundError,
     SpacesNotConfiguredError,
 )
@@ -403,3 +404,260 @@ class TestSnapshotManagerOperations:
 
         with pytest.raises(SnapshotNotFoundError):
             snapshot_manager.get_snapshot_download_url("nonexistent")
+
+
+# =============================================================================
+# Incremental Snapshot Tests
+# =============================================================================
+
+
+class TestSnapshotMetadataBackwardCompat:
+    """Tests for backward compatibility of SnapshotMetadata with incremental fields."""
+
+    def test_old_metadata_without_incremental_fields(self):
+        """Old metadata JSON (without incremental fields) deserializes correctly."""
+        old_json = {
+            "snapshot_id": "snap-old",
+            "created_at": 1700000000.0,
+            "sandbox_image": "python",
+            "size_bytes": 1024,
+            "paths": ["/workspace"],
+            "description": "Old snapshot",
+            "tags": {"env": "test"},
+        }
+        meta = SnapshotMetadata(**old_json)
+
+        assert meta.snapshot_type == "full"
+        assert meta.parent_snapshot_id is None
+        assert meta.chain_depth == 0
+        assert meta.chain_root_id is None
+        assert meta.files_changed == 0
+        assert meta.files_deleted == 0
+        assert meta.dep_layer_id is None
+        assert meta.lockfile_hash is None
+
+    def test_incremental_metadata_round_trip(self):
+        """Incremental metadata serializes and deserializes correctly."""
+        from dataclasses import asdict
+
+        meta = SnapshotMetadata(
+            snapshot_id="snap-incr",
+            created_at=1700000000.0,
+            sandbox_image="python",
+            size_bytes=512,
+            paths=["/workspace"],
+            snapshot_type="incremental",
+            parent_snapshot_id="snap-base",
+            chain_depth=2,
+            chain_root_id="snap-root",
+            files_changed=5,
+            files_deleted=1,
+        )
+
+        json_str = json.dumps(asdict(meta))
+        parsed = json.loads(json_str)
+        restored = SnapshotMetadata(**parsed)
+
+        assert restored.snapshot_type == "incremental"
+        assert restored.parent_snapshot_id == "snap-base"
+        assert restored.chain_depth == 2
+        assert restored.chain_root_id == "snap-root"
+        assert restored.files_changed == 5
+        assert restored.files_deleted == 1
+
+    def test_repr_includes_incremental_info(self):
+        """repr shows type and chain_depth for incremental snapshots."""
+        meta = SnapshotMetadata(
+            snapshot_id="snap-incr",
+            created_at=1.0,
+            sandbox_image="python",
+            size_bytes=100,
+            paths=["/workspace"],
+            snapshot_type="incremental",
+            chain_depth=3,
+        )
+        r = repr(meta)
+        assert "incremental" in r
+        assert "chain_depth=3" in r
+
+    def test_repr_omits_type_for_full(self):
+        """repr omits type info for full snapshots."""
+        meta = SnapshotMetadata(
+            snapshot_id="snap-full",
+            created_at=1.0,
+            sandbox_image="python",
+            size_bytes=100,
+            paths=["/workspace"],
+        )
+        r = repr(meta)
+        assert "incremental" not in r
+        assert "chain_depth" not in r
+
+
+class TestResolveChain:
+    """Tests for resolve_chain() with mocked Spaces."""
+
+    @pytest.fixture
+    def manager_with_snapshots(self):
+        """Create a SnapshotManager with pre-loaded snapshot metadata."""
+        config = SpacesConfig(bucket="test-bucket", region="nyc3", access_key="key", secret_key="secret")
+
+        with patch("do_app_sandbox.snapshot.SpacesClient") as MockClient:
+            mock_spaces = MagicMock()
+            MockClient.return_value = mock_spaces
+
+            from do_app_sandbox.snapshot import SnapshotManager
+
+            manager = SnapshotManager(spaces_config=config)
+            manager._spaces = mock_spaces
+
+            # Pre-populate snapshot metadata store
+            snapshots = {
+                "snap-root": SnapshotMetadata(
+                    snapshot_id="snap-root", created_at=1.0, sandbox_image="python",
+                    size_bytes=1000, paths=["/workspace"], snapshot_type="full",
+                ),
+                "snap-incr1": SnapshotMetadata(
+                    snapshot_id="snap-incr1", created_at=2.0, sandbox_image="python",
+                    size_bytes=100, paths=["/workspace"], snapshot_type="incremental",
+                    parent_snapshot_id="snap-root", chain_depth=1, chain_root_id="snap-root",
+                    files_changed=3,
+                ),
+                "snap-incr2": SnapshotMetadata(
+                    snapshot_id="snap-incr2", created_at=3.0, sandbox_image="python",
+                    size_bytes=50, paths=["/workspace"], snapshot_type="incremental",
+                    parent_snapshot_id="snap-incr1", chain_depth=2, chain_root_id="snap-root",
+                    files_changed=1, files_deleted=1,
+                ),
+            }
+
+            def mock_get_object(key):
+                for sid, meta in snapshots.items():
+                    if key == f"snapshots/{sid}/metadata.json":
+                        from dataclasses import asdict
+                        return json.dumps(asdict(meta)).encode()
+                raise Exception("Not found")
+
+            mock_spaces.get_object.side_effect = mock_get_object
+            return manager
+
+    def test_resolve_chain_happy_path(self, manager_with_snapshots):
+        """Resolves chain from tip to root correctly."""
+        chain = manager_with_snapshots.resolve_chain("snap-incr2")
+
+        assert len(chain) == 3
+        assert chain[0].snapshot_id == "snap-root"
+        assert chain[0].snapshot_type == "full"
+        assert chain[1].snapshot_id == "snap-incr1"
+        assert chain[1].snapshot_type == "incremental"
+        assert chain[2].snapshot_id == "snap-incr2"
+        assert chain[2].snapshot_type == "incremental"
+
+    def test_resolve_chain_single_full(self, manager_with_snapshots):
+        """Full snapshot resolves to single-element chain."""
+        chain = manager_with_snapshots.resolve_chain("snap-root")
+
+        assert len(chain) == 1
+        assert chain[0].snapshot_id == "snap-root"
+        assert chain[0].snapshot_type == "full"
+
+    def test_resolve_chain_from_middle(self, manager_with_snapshots):
+        """Resolving from middle of chain includes root and middle."""
+        chain = manager_with_snapshots.resolve_chain("snap-incr1")
+
+        assert len(chain) == 2
+        assert chain[0].snapshot_id == "snap-root"
+        assert chain[1].snapshot_id == "snap-incr1"
+
+    def test_resolve_chain_broken_chain(self, manager_with_snapshots):
+        """Raises SnapshotChainError for broken chain."""
+        with pytest.raises(SnapshotChainError, match="not found"):
+            manager_with_snapshots.resolve_chain("nonexistent-snap")
+
+    def test_resolve_chain_detects_cycle(self):
+        """Raises SnapshotChainError for cyclic chain."""
+        config = SpacesConfig(bucket="test", region="nyc3", access_key="k", secret_key="s")
+
+        with patch("do_app_sandbox.snapshot.SpacesClient") as MockClient:
+            mock_spaces = MagicMock()
+            MockClient.return_value = mock_spaces
+
+            from do_app_sandbox.snapshot import SnapshotManager
+
+            manager = SnapshotManager(spaces_config=config)
+            manager._spaces = mock_spaces
+
+            # Create a cycle: A → B → A
+            cycle_snaps = {
+                "snap-a": SnapshotMetadata(
+                    snapshot_id="snap-a", created_at=1.0, sandbox_image="python",
+                    size_bytes=100, paths=["/workspace"], snapshot_type="incremental",
+                    parent_snapshot_id="snap-b",
+                ),
+                "snap-b": SnapshotMetadata(
+                    snapshot_id="snap-b", created_at=2.0, sandbox_image="python",
+                    size_bytes=100, paths=["/workspace"], snapshot_type="incremental",
+                    parent_snapshot_id="snap-a",
+                ),
+            }
+
+            def mock_get(key):
+                for sid, meta in cycle_snaps.items():
+                    if key == f"snapshots/{sid}/metadata.json":
+                        from dataclasses import asdict
+                        return json.dumps(asdict(meta)).encode()
+                raise Exception("Not found")
+
+            mock_spaces.get_object.side_effect = mock_get
+
+            with pytest.raises(SnapshotChainError, match="Cycle detected"):
+                manager.resolve_chain("snap-a")
+
+    def test_resolve_chain_no_full_root(self):
+        """Raises SnapshotChainError when chain doesn't reach a full snapshot."""
+        config = SpacesConfig(bucket="test", region="nyc3", access_key="k", secret_key="s")
+
+        with patch("do_app_sandbox.snapshot.SpacesClient") as MockClient:
+            mock_spaces = MagicMock()
+            MockClient.return_value = mock_spaces
+
+            from do_app_sandbox.snapshot import SnapshotManager
+
+            manager = SnapshotManager(spaces_config=config)
+            manager._spaces = mock_spaces
+
+            # Incremental with no parent and not marked as full
+            orphan = SnapshotMetadata(
+                snapshot_id="snap-orphan", created_at=1.0, sandbox_image="python",
+                size_bytes=100, paths=["/workspace"], snapshot_type="incremental",
+                parent_snapshot_id=None,  # No parent, but type is incremental
+            )
+
+            def mock_get(key):
+                if "snap-orphan" in key:
+                    from dataclasses import asdict
+                    return json.dumps(asdict(orphan)).encode()
+                raise Exception("Not found")
+
+            mock_spaces.get_object.side_effect = mock_get
+
+            with pytest.raises(SnapshotChainError, match="does not terminate"):
+                manager.resolve_chain("snap-orphan")
+
+
+class TestIncrementalSnapshotKeyFormat:
+    """Tests for incremental snapshot Spaces key format."""
+
+    def test_manifest_key_format(self):
+        """manifest.txt stored alongside archive."""
+        prefix = "snapshots/"
+        snapshot_id = "snap-test"
+        manifest_key = f"{prefix}{snapshot_id}/manifest.txt"
+        assert manifest_key == "snapshots/snap-test/manifest.txt"
+
+    def test_deletions_key_format(self):
+        """deletions.txt stored alongside archive."""
+        prefix = "snapshots/"
+        snapshot_id = "snap-test"
+        deletions_key = f"{prefix}{snapshot_id}/deletions.txt"
+        assert deletions_key == "snapshots/snap-test/deletions.txt"


### PR DESCRIPTION
## Summary

- Adds design document for incremental snapshot support in the sandbox SDK
- Proposes delta-only snapshots via `find -newer` marker files, content-addressed dependency layers keyed by lockfile hash, and snapshot chains with ancestry tracking and compaction
- Addresses the current full-tar-every-time approach which re-uploads 200-400MB of unchanged dependencies on each snapshot

### Key design decisions

- **No overlayfs/rsync** — containers don't support them; uses `find -newer`, `tar -T`, and `comm -23` for change detection, incremental tar, and deletion tracking
- **Backward compatible** — all new `SnapshotMetadata` fields have defaults; existing `create_snapshot()` / `restore_snapshot()` unchanged
- **SDK primitives only** — snapshot trigger logic (when to snapshot) belongs in orchestration layers, not the SDK
- **~90% storage reduction** for typical edit-snapshot cycles (10 snapshots of a Python project: 2.6GB → ~253MB)

### New API surface (proposed)

- `create_incremental_snapshot()` — delta-only tar
- `restore_snapshot_chain()` — apply base + incrementals in order
- `create_dep_layer()` / `restore_dep_layer()` — content-addressed deps
- `smart_snapshot()` — auto-detect full vs incremental, separate deps, auto-compact
- `compact_chain()` — merge chain into single full snapshot

### 5-phase rollout

1. Foundation (metadata, chain resolution, manifests)
2. Incremental snapshots
3. Dependency layers
4. Smart snapshot + compaction
5. Manager/pool integration

## Test plan

- [ ] Review design doc for completeness and correctness
- [ ] Validate shell commands work in sandbox containers (`find -newer`, `tar -T`, `comm -23`)
- [ ] Confirm backward compatibility of metadata schema changes
- [ ] Approve phased implementation plan